### PR TITLE
Update DriveServiceWrapper.cs

### DIFF
--- a/RaptorSheets.Core.Tests/RaptorSheets.Core.Tests.csproj
+++ b/RaptorSheets.Core.Tests/RaptorSheets.Core.Tests.csproj
@@ -20,14 +20,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/RaptorSheets.Core/RaptorSheets.Core.csproj
+++ b/RaptorSheets.Core/RaptorSheets.Core.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Drive.v3" Version="1.70.0.3893" />
-    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.70.0.3819" />
+    <PackageReference Include="Google.Apis.Drive.v3" Version="1.73.0.4112" />
+    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.73.0.4061" />
   </ItemGroup>
 
 </Project>

--- a/RaptorSheets.Core/Wrappers/DriveServiceWrapper.cs
+++ b/RaptorSheets.Core/Wrappers/DriveServiceWrapper.cs
@@ -51,7 +51,16 @@ public class DriveServiceWrapper : DriveService, IDriveServiceWrapper
     public async Task<IList<File>> ListSpreadsheets()
     {
         var listRequest = _driveService.Files.List();
-        listRequest.Q = "mimeType='application/vnd.google-apps.spreadsheet' and trashed = false";
+        // This query is safe to use with restricted scopes like `drive.file`, but the
+        // response is still constrained by the caller's OAuth grant. Under `drive.file`,
+        // Google typically returns only files the current user created with or explicitly
+        // opened through the app. Shared files from other accounts usually require a broader
+        // scope such as `drive.readonly` or `drive` to appear automatically in list results.
+        listRequest.Q = "mimeType='application/vnd.google-apps.spreadsheet' and trashed = false and ('me' in owners or sharedWithMe = true)";
+        // These flags allow callers with broader Drive scopes to include shared-drive content.
+        // They do not expand visibility on their own and do not override restricted scopes.
+        listRequest.SupportsAllDrives = true;
+        listRequest.IncludeItemsFromAllDrives = true;
         listRequest.Fields = "files(id, name, mimeType)";
         var result = await listRequest.ExecuteAsync();
         return result.Files;

--- a/RaptorSheets.Gig.Tests/RaptorSheets.Gig.Tests.csproj
+++ b/RaptorSheets.Gig.Tests/RaptorSheets.Gig.Tests.csproj
@@ -67,16 +67,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/RaptorSheets.Gig/Helpers/GenerateSheetsHelpers.cs
+++ b/RaptorSheets.Gig/Helpers/GenerateSheetsHelpers.cs
@@ -13,9 +13,6 @@ namespace RaptorSheets.Gig.Helpers;
 
 public static class GenerateSheetsHelpers
 {
-    private static BatchUpdateSpreadsheetRequest? _batchUpdateSpreadsheetRequest;
-    private static List<RepeatCellRequest>? _repeatCellRequests;
-
     public static BatchUpdateSpreadsheetRequest Generate(List<string> sheets)
     {
         if (sheets.Count == 0)
@@ -24,9 +21,11 @@ public static class GenerateSheetsHelpers
             return new BatchUpdateSpreadsheetRequest { Requests = new List<Request>() };
         }
 
-        _batchUpdateSpreadsheetRequest = new BatchUpdateSpreadsheetRequest();
-        _batchUpdateSpreadsheetRequest.Requests = [];
-        _repeatCellRequests = [];
+        var batchUpdateSpreadsheetRequest = new BatchUpdateSpreadsheetRequest
+        {
+            Requests = []
+        };
+        var repeatCellRequests = new List<RepeatCellRequest>();
 
         foreach (var sheet in sheets)
         {
@@ -34,26 +33,26 @@ public static class GenerateSheetsHelpers
             var random = new Random();
             sheetModel.Id = random.Next();
 
-            _batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateSheetPropertes(sheetModel));
+            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateSheetPropertes(sheetModel));
 
             var appendDimension = GoogleRequestHelpers.GenerateAppendDimension(sheetModel);
             if (appendDimension != null)
             {
-                _batchUpdateSpreadsheetRequest.Requests.Add(appendDimension);
+                batchUpdateSpreadsheetRequest.Requests.Add(appendDimension);
             }
 
-            _batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateAppendCells(sheetModel));
-            GenerateHeadersFormatAndProtection(sheetModel);
-            _batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateBandingRequest(sheetModel));
-            _batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateProtectedRangeForHeaderOrSheet(sheetModel));
+            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateAppendCells(sheetModel));
+            GenerateHeadersFormatAndProtection(sheetModel, batchUpdateSpreadsheetRequest, repeatCellRequests);
+            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateBandingRequest(sheetModel));
+            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateProtectedRangeForHeaderOrSheet(sheetModel));
         }
 
-        foreach (var request in _repeatCellRequests)
+        foreach (var request in repeatCellRequests)
         {
-            _batchUpdateSpreadsheetRequest.Requests.Add(new Request { RepeatCell = request });
+            batchUpdateSpreadsheetRequest.Requests.Add(new Request { RepeatCell = request });
         }
 
-        return _batchUpdateSpreadsheetRequest;
+        return batchUpdateSpreadsheetRequest;
     }
 
     public static List<string> GetSheetNames()
@@ -84,7 +83,10 @@ public static class GenerateSheetsHelpers
         };
     }
 
-    private static void GenerateHeadersFormatAndProtection(SheetModel sheet)
+    private static void GenerateHeadersFormatAndProtection(
+        SheetModel sheet,
+        BatchUpdateSpreadsheetRequest batchUpdateSpreadsheetRequest,
+        List<RepeatCellRequest> repeatCellRequests)
     {
         // Ensure headers have proper Column/Index assignments prior to formatting, like Stock implementation
         sheet.Headers.UpdateColumns();
@@ -103,7 +105,7 @@ public static class GenerateSheetsHelpers
             // If whole sheet isn't protected then protect certain columns
             if (!string.IsNullOrEmpty(header.Formula) && !sheet.ProtectSheet)
             {
-                _batchUpdateSpreadsheetRequest!.Requests.Add(GoogleRequestHelpers.GenerateColumnProtection(range));
+                batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateColumnProtection(range));
             }
 
             // If there's no format or validation then go to next header
@@ -135,7 +137,7 @@ public static class GenerateSheetsHelpers
                 repeatCellModel.DataValidation = GigSheetHelpers.GetDataValidation(header.Validation.GetValueFromName<ValidationEnum>(), columnRange);
             }
 
-            _repeatCellRequests!.Add(GoogleRequestHelpers.GenerateRepeatCellRequest(repeatCellModel));
+            repeatCellRequests.Add(GoogleRequestHelpers.GenerateRepeatCellRequest(repeatCellModel));
         }
     }  
 }

--- a/RaptorSheets.Gig/RaptorSheets.Gig.csproj
+++ b/RaptorSheets.Gig/RaptorSheets.Gig.csproj
@@ -25,8 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Drive.v3" Version="1.70.0.3893" />
-    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.70.0.3819" />
+    <PackageReference Include="Google.Apis.Drive.v3" Version="1.73.0.4112" />
+    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.73.0.4061" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RaptorSheets.Stock.Tests/RaptorSheets.Stock.Tests.csproj
+++ b/RaptorSheets.Stock.Tests/RaptorSheets.Stock.Tests.csproj
@@ -16,16 +16,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/RaptorSheets.Test/RaptorSheets.Test.Common.csproj
+++ b/RaptorSheets.Test/RaptorSheets.Test.Common.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates the spreadsheet listing logic in `DriveServiceWrapper` to improve how spreadsheets are discovered, especially in environments with restricted OAuth scopes. The query now explicitly includes spreadsheets owned by or shared with the user, and additional flags are set to support shared-drive content for users with broader permissions.

**Improvements to spreadsheet discovery and Drive API usage:**

* Updated the file query in `ListSpreadsheets()` to include only spreadsheets owned by or shared with the current user, making results more accurate under restricted scopes like `drive.file`.
* Enabled `SupportsAllDrives` and `IncludeItemsFromAllDrives` on the Drive API request, allowing the listing to include shared-drive content for users with appropriate permissions.
* Added detailed comments explaining the behavior of the query and flags under different OAuth scopes, clarifying limitations and expected results.