### PR TITLE
Add First Trip/Last Trip to Deliveries and Locations sheets

### DIFF
--- a/RaptorSheets.Core.Tests/Unit/Helpers/GoogleFormulaBuilderTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/GoogleFormulaBuilderTests.cs
@@ -637,5 +637,40 @@ public class GoogleFormulaBuilderTests
         Assert.StartsWith("=QUERY({Trips!A2:A,Trips!B2:B},\"select Col1, Col2, count(Col1)", result);
     }
 
+    [Fact]
+    public void BuildQueryGroupTwoColumns_WithAggregateColumns_ShouldSupportMixedFunctions()
+    {
+        // Arrange
+        var aggregateColumns = new (string Header, string Range, string AggregateFunction)[]
+        {
+            ("Pay", "Trips!C2:C", "sum"),
+            ("First Trip", "Trips!D2:D", "min"),
+            ("Last Trip", "Trips!D2:D", "max")
+        };
+
+        // Act
+        var result = GoogleFormulaBuilder.BuildQueryGroupTwoColumns("Name", "Address", "Trips!A2:A", "Trips!B2:B", "Count", aggregateColumns);
+
+        // Assert
+        Assert.StartsWith("=QUERY({Trips!A2:A,Trips!B2:B,Trips!C2:C,Trips!D2:D,Trips!D2:D},", result);
+        Assert.Contains("select Col1, Col2, count(Col1), sum(Col3), min(Col4), max(Col5)", result);
+        Assert.Contains("label Col1 'Name', Col2 'Address', count(Col1) 'Count', sum(Col3) 'Pay', min(Col4) 'First Trip', max(Col5) 'Last Trip'", result);
+    }
+
+    [Fact]
+    public void BuildQueryGroupTwoColumns_SumOnlyOverload_ShouldDelegateToAggregateOverload()
+    {
+        // Arrange
+        var sumColumns = new[] { ("Pay", "Trips!C2:C") };
+
+        // Act
+        var viaSumOverload = GoogleFormulaBuilder.BuildQueryGroupTwoColumns("Name", "Address", "Trips!A2:A", "Trips!B2:B", "Count", sumColumns);
+        var viaAggregateOverload = GoogleFormulaBuilder.BuildQueryGroupTwoColumns("Name", "Address", "Trips!A2:A", "Trips!B2:B", "Count",
+            new (string, string, string)[] { ("Pay", "Trips!C2:C", "sum") });
+
+        // Assert - both overloads produce an identical formula
+        Assert.Equal(viaAggregateOverload, viaSumOverload);
+    }
+
     #endregion
 }

--- a/RaptorSheets.Core/Helpers/GoogleFormulaBuilder.cs
+++ b/RaptorSheets.Core/Helpers/GoogleFormulaBuilder.cs
@@ -142,19 +142,29 @@ public static class GoogleFormulaBuilder
     /// </summary>
     public static string BuildQueryGroupTwoColumns(string header1, string header2, string range1, string range2, string countHeader, IEnumerable<(string Header, string Range)> sumColumns, bool countColumnIsSecond = false)
     {
-        var countExpr = countColumnIsSecond ? "count(Col2)" : "count(Col1)";
-        var sumColumnList = sumColumns.ToList();
+        return BuildQueryGroupTwoColumns(header1, header2, range1, range2, countHeader, sumColumns.Select(s => (s.Header, s.Range, AggregateFunction: "sum")), countColumnIsSecond);
+    }
 
-        var ranges = "{" + range1 + "," + range2 + string.Concat(sumColumnList.Select(s => "," + s.Range)) + "}";
+    /// <summary>
+    /// Builds a QUERY formula that groups two parallel ranges by the first two columns
+    /// and returns a header row, a count column, and one or more aggregated columns
+    /// (e.g. sum(Pay), min(Date), max(Date)) per group.
+    /// </summary>
+    public static string BuildQueryGroupTwoColumns(string header1, string header2, string range1, string range2, string countHeader, IEnumerable<(string Header, string Range, string AggregateFunction)> aggregateColumns, bool countColumnIsSecond = false)
+    {
+        var countExpr = countColumnIsSecond ? "count(Col2)" : "count(Col1)";
+        var aggregateColumnList = aggregateColumns.ToList();
+
+        var ranges = "{" + range1 + "," + range2 + string.Concat(aggregateColumnList.Select(a => "," + a.Range)) + "}";
 
         var selectColumns = new List<string> { "Col1", "Col2", countExpr };
         var labelClauses = new List<string> { "Col1 '" + header1 + "'", "Col2 '" + header2 + "'", countExpr + " '" + countHeader + "'" };
 
-        for (var i = 0; i < sumColumnList.Count; i++)
+        for (var i = 0; i < aggregateColumnList.Count; i++)
         {
-            var sumExpr = $"sum(Col{i + 3})";
-            selectColumns.Add(sumExpr);
-            labelClauses.Add(sumExpr + " '" + sumColumnList[i].Header + "'");
+            var aggregateExpr = $"{aggregateColumnList[i].AggregateFunction}(Col{i + 3})";
+            selectColumns.Add(aggregateExpr);
+            labelClauses.Add(aggregateExpr + " '" + aggregateColumnList[i].Header + "'");
         }
 
         var innerQuery = "\"select " + string.Join(", ", selectColumns) +

--- a/RaptorSheets.Gig.Tests/Unit/Mappers/MapperGetSheetTests.cs
+++ b/RaptorSheets.Gig.Tests/Unit/Mappers/MapperGetSheetTests.cs
@@ -327,19 +327,30 @@ public class MapperGetSheetTests
         // Act
         var sheet = DeliveryMapper.GetSheet();
         var tripsHeader = sheet.Headers.First(h => h.Name.ToString() == "Trips");
+        var firstTripHeader = sheet.Headers.First(h => h.Name.ToString() == "First Trip");
+        var lastTripHeader = sheet.Headers.First(h => h.Name.ToString() == "Last Trip");
         var amountPerTripHeader = sheet.Headers.First(h => h.Name.ToString() == "Amt/Trip");
         var amountPerDistanceHeader = sheet.Headers.First(h => h.Name.ToString() == "Amt/Dist");
 
-        // Assert - QUERY formula groups by Name/Address and sums Pay/Tips/Bonus/Total/Dist
+        // Assert - QUERY formula groups by Name/Address and sums Pay/Tips/Bonus/Total/Dist, plus
+        // min/max First Trip/Last Trip from Date - all part of the same query, since a QUERY's
+        // spilled array is contiguous and must include everything up to Amt/Trip/Amt/Dist, which
+        // are separate ARRAYFORMULAs placed after it.
         var queryFormula = sheet.Headers[0].Formula;
         Assert.NotNull(queryFormula);
         Assert.StartsWith("=QUERY({", queryFormula);
-        Assert.Contains("label Col1 'Name', Col2 'Address', count(Col1) 'Trips', sum(Col3) 'Pay', sum(Col4) 'Tips', sum(Col5) 'Bonus', sum(Col6) 'Total', sum(Col7) 'Dist'", queryFormula);
+        Assert.Contains("select Col1, Col2, count(Col1), sum(Col3), sum(Col4), sum(Col5), sum(Col6), sum(Col7), min(Col8), max(Col9)", queryFormula);
+        Assert.Contains("label Col1 'Name', Col2 'Address', count(Col1) 'Trips', sum(Col3) 'Pay', sum(Col4) 'Tips', sum(Col5) 'Bonus', sum(Col6) 'Total', sum(Col7) 'Dist', min(Col8) 'First Trip', max(Col9) 'Last Trip'", queryFormula);
 
-        // Assert - Trips is the renamed Count column produced by the query, not a formula of its own
+        // Assert - Trips, First Trip and Last Trip are all produced by the query, not formulas of their own
         Assert.True(tripsHeader.HideHeaderName);
+        Assert.True(firstTripHeader.HideHeaderName);
+        Assert.True(lastTripHeader.HideHeaderName);
+        Assert.True(string.IsNullOrEmpty(firstTripHeader.Formula));
+        Assert.True(string.IsNullOrEmpty(lastTripHeader.Formula));
 
         // Assert - Amt/Trip and Amt/Dist are separate ARRAYFORMULAs referencing this sheet's own columns
+        // (Total/Trips/Distance stay at columns G/C/H regardless of First Trip/Last Trip being added)
         Assert.NotNull(amountPerTripHeader.Formula);
         Assert.Contains("G1:G/IF(C1:C=0,1,C1:C)", amountPerTripHeader.Formula);
         Assert.NotNull(amountPerDistanceHeader.Formula);
@@ -362,16 +373,25 @@ public class MapperGetSheetTests
     {
         // Act
         var sheet = LocationMapper.GetSheet();
+        var firstTripHeader = sheet.Headers.First(h => h.Name.ToString() == "First Trip");
+        var lastTripHeader = sheet.Headers.First(h => h.Name.ToString() == "Last Trip");
         var amountPerTripHeader = sheet.Headers.First(h => h.Name.ToString() == "Amt/Trip");
         var amountPerDistanceHeader = sheet.Headers.First(h => h.Name.ToString() == "Amt/Dist");
 
-        // Assert - QUERY groups by Place/Address, counting Col2 (Address), and sums Pay/Tips/Bonus/Total/Dist
+        // Assert - QUERY groups by Place/Address, counting Col2 (Address), and sums Pay/Tips/Bonus/Total/Dist,
+        // plus min/max First Trip/Last Trip from Date
         var queryFormula = sheet.Headers[0].Formula;
         Assert.NotNull(queryFormula);
         Assert.Contains("count(Col2)", queryFormula);
-        Assert.Contains("label Col1 'Place', Col2 'Address', count(Col2) 'Trips', sum(Col3) 'Pay', sum(Col4) 'Tips', sum(Col5) 'Bonus', sum(Col6) 'Total', sum(Col7) 'Dist'", queryFormula);
+        Assert.Contains("select Col1, Col2, count(Col2), sum(Col3), sum(Col4), sum(Col5), sum(Col6), sum(Col7), min(Col8), max(Col9)", queryFormula);
+        Assert.Contains("label Col1 'Place', Col2 'Address', count(Col2) 'Trips', sum(Col3) 'Pay', sum(Col4) 'Tips', sum(Col5) 'Bonus', sum(Col6) 'Total', sum(Col7) 'Dist', min(Col8) 'First Trip', max(Col9) 'Last Trip'", queryFormula);
 
-        // Regression: same HideHeaderName gap as DeliveryMapper - formulas must survive row-data conversion
+        // Assert - First Trip and Last Trip are produced by the query, not formulas of their own
+        Assert.True(firstTripHeader.HideHeaderName);
+        Assert.True(lastTripHeader.HideHeaderName);
+
+        // Regression: same HideHeaderName gap as DeliveryMapper - Amt/Trip/Amt/Dist formulas must
+        // survive row-data conversion
         Assert.False(amountPerTripHeader.HideHeaderName);
         Assert.False(amountPerDistanceHeader.HideHeaderName);
 

--- a/RaptorSheets.Gig/Entities/DeliveryEntity.cs
+++ b/RaptorSheets.Gig/Entities/DeliveryEntity.cs
@@ -2,6 +2,7 @@ using RaptorSheets.Core.Attributes;
 using RaptorSheets.Core.Enums;
 using RaptorSheets.Gig.Constants;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace RaptorSheets.Gig.Entities;
 
@@ -31,6 +32,14 @@ public class DeliveryEntity : SheetRowEntityBase
 
     [Column(SheetsConfig.HeaderNames.Distance, FormatEnum.DISTANCE)]
     public decimal? Distance { get; set; }
+
+    [Column(SheetsConfig.HeaderNames.VisitFirst)]
+    [JsonPropertyName("firstTrip")]
+    public string FirstTrip { get; set; } = "";
+
+    [Column(SheetsConfig.HeaderNames.VisitLast)]
+    [JsonPropertyName("lastTrip")]
+    public string LastTrip { get; set; } = "";
 
     [Column(SheetsConfig.HeaderNames.AmountPerTrip, FormatEnum.ACCOUNTING)]
     public decimal AmountPerTrip { get; set; }

--- a/RaptorSheets.Gig/Entities/LocationEntity.cs
+++ b/RaptorSheets.Gig/Entities/LocationEntity.cs
@@ -2,6 +2,7 @@ using RaptorSheets.Core.Attributes;
 using RaptorSheets.Core.Enums;
 using RaptorSheets.Gig.Constants;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace RaptorSheets.Gig.Entities;
 
@@ -31,6 +32,14 @@ public class LocationEntity : SheetRowEntityBase
 
     [Column(SheetsConfig.HeaderNames.Distance, FormatEnum.DISTANCE)]
     public decimal? Distance { get; set; }
+
+    [Column(SheetsConfig.HeaderNames.VisitFirst)]
+    [JsonPropertyName("firstTrip")]
+    public string FirstTrip { get; set; } = "";
+
+    [Column(SheetsConfig.HeaderNames.VisitLast)]
+    [JsonPropertyName("lastTrip")]
+    public string LastTrip { get; set; } = "";
 
     [Column(SheetsConfig.HeaderNames.AmountPerTrip, FormatEnum.ACCOUNTING)]
     public decimal AmountPerTrip { get; set; }

--- a/RaptorSheets.Gig/Mappers/DeliveryMapper.cs
+++ b/RaptorSheets.Gig/Mappers/DeliveryMapper.cs
@@ -1,3 +1,4 @@
+using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Models.Google;
@@ -19,20 +20,24 @@ public static class DeliveryMapper
         // Keep one real header, pad the rest up to the original header count
         sheet.Headers.EnsureHeaderPlaceholders(1);
 
-        // Build the single QUERY formula that produces Name|Address|Trips|Pay|Tips|Bonus|Total|Dist from Trips
+        // Build the single QUERY formula that produces
+        // Name|Address|Trips|Pay|Tips|Bonus|Total|Dist|First Trip|Last Trip from Trips
         var tripSheet = SheetsConfig.TripSheet;
         tripSheet.Headers.UpdateColumns();
 
         var nameRange = tripSheet.GetRange(SheetsConfig.HeaderNames.Name, 2);
         var endAddressRange = tripSheet.GetRange(SheetsConfig.HeaderNames.AddressEnd, 2);
+        var dateRange = tripSheet.GetRange(SheetsConfig.HeaderNames.Date, 2);
 
-        var sumColumns = new[]
+        var aggregateColumns = new (string Header, string Range, string AggregateFunction)[]
         {
-            (SheetsConfig.HeaderNames.Pay, tripSheet.GetRange(SheetsConfig.HeaderNames.Pay, 2)),
-            (SheetsConfig.HeaderNames.Tips, tripSheet.GetRange(SheetsConfig.HeaderNames.Tips, 2)),
-            (SheetsConfig.HeaderNames.Bonus, tripSheet.GetRange(SheetsConfig.HeaderNames.Bonus, 2)),
-            (SheetsConfig.HeaderNames.Total, tripSheet.GetRange(SheetsConfig.HeaderNames.Total, 2)),
-            (SheetsConfig.HeaderNames.Distance, tripSheet.GetRange(SheetsConfig.HeaderNames.Distance, 2))
+            (SheetsConfig.HeaderNames.Pay, tripSheet.GetRange(SheetsConfig.HeaderNames.Pay, 2), "sum"),
+            (SheetsConfig.HeaderNames.Tips, tripSheet.GetRange(SheetsConfig.HeaderNames.Tips, 2), "sum"),
+            (SheetsConfig.HeaderNames.Bonus, tripSheet.GetRange(SheetsConfig.HeaderNames.Bonus, 2), "sum"),
+            (SheetsConfig.HeaderNames.Total, tripSheet.GetRange(SheetsConfig.HeaderNames.Total, 2), "sum"),
+            (SheetsConfig.HeaderNames.Distance, tripSheet.GetRange(SheetsConfig.HeaderNames.Distance, 2), "sum"),
+            (SheetsConfig.HeaderNames.VisitFirst, dateRange, "min"),
+            (SheetsConfig.HeaderNames.VisitLast, dateRange, "max")
         };
 
         var query = GoogleFormulaBuilder.BuildQueryGroupTwoColumns(
@@ -41,7 +46,7 @@ public static class DeliveryMapper
             nameRange,
             endAddressRange,
             SheetsConfig.HeaderNames.Trips,
-            sumColumns
+            aggregateColumns
         );
 
         // Place formula in first header so it will spill across columns
@@ -50,17 +55,34 @@ public static class DeliveryMapper
             sheet.Headers[0].Formula = query;
         }
 
-        // Amt/Trip and Amt/Dist are derived from the sheet's own spilled Trips/Total/Distance columns,
-        // so they're separate self-referencing ARRAYFORMULAs rather than part of the QUERY spill.
+        var firstTripHeader = sheet.Headers.FirstOrDefault(h => h.Name == SheetsConfig.HeaderNames.VisitFirst);
+        if (firstTripHeader != null)
+        {
+            firstTripHeader.Format = FormatEnum.DATE;
+        }
+
+        var lastTripHeader = sheet.Headers.FirstOrDefault(h => h.Name == SheetsConfig.HeaderNames.VisitLast);
+        if (lastTripHeader != null)
+        {
+            lastTripHeader.Format = FormatEnum.DATE;
+        }
+
+        // Amt/Trip and Amt/Dist are derived from the sheet's own spilled Trips/Total/Distance
+        // columns, so they're separate self-referencing ARRAYFORMULAs rather than part of the
+        // QUERY spill (a QUERY's spilled array is contiguous - it can't leave gaps for other
+        // formulas in the middle and resume after, so they have to come after everything the
+        // query itself produces, including First Trip/Last Trip).
         // EnsureHeaderPlaceholders(1) marks every header past index 0 as HideHeaderName, which also
         // suppresses writing the cell's UserEnteredValue entirely (see SheetHelpers.HeadersToRowData) -
-        // these two headers need that flag cleared or their formulas never make it onto the sheet.
+        // these headers need that flag cleared or their formulas never make it onto the sheet.
+        var nameKeyRange = sheet.GetLocalRange(SheetsConfig.HeaderNames.Name);
+
         var amountPerTripHeader = sheet.Headers.FirstOrDefault(h => h.Name == SheetsConfig.HeaderNames.AmountPerTrip);
         if (amountPerTripHeader != null)
         {
             amountPerTripHeader.HideHeaderName = false;
             amountPerTripHeader.Formula = GigFormulaBuilder.BuildArrayFormulaAmountPerTrip(
-                sheet.GetLocalRange(SheetsConfig.HeaderNames.Name),
+                nameKeyRange,
                 SheetsConfig.HeaderNames.AmountPerTrip,
                 sheet.GetLocalRange(SheetsConfig.HeaderNames.Total),
                 sheet.GetLocalRange(SheetsConfig.HeaderNames.Trips));
@@ -71,7 +93,7 @@ public static class DeliveryMapper
         {
             amountPerDistanceHeader.HideHeaderName = false;
             amountPerDistanceHeader.Formula = GigFormulaBuilder.BuildArrayFormulaAmountPerDistance(
-                sheet.GetLocalRange(SheetsConfig.HeaderNames.Name),
+                nameKeyRange,
                 SheetsConfig.HeaderNames.AmountPerDistance,
                 sheet.GetLocalRange(SheetsConfig.HeaderNames.Total),
                 sheet.GetLocalRange(SheetsConfig.HeaderNames.Distance));

--- a/RaptorSheets.Gig/Mappers/LocationMapper.cs
+++ b/RaptorSheets.Gig/Mappers/LocationMapper.cs
@@ -1,3 +1,4 @@
+using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Models.Google;
@@ -23,14 +24,17 @@ public static class LocationMapper
 
         var placeRange = tripSheet.GetRange(SheetsConfig.HeaderNames.Place, 2);
         var addressRange = tripSheet.GetRange(SheetsConfig.HeaderNames.AddressStart, 2);
+        var dateRange = tripSheet.GetRange(SheetsConfig.HeaderNames.Date, 2);
 
-        var sumColumns = new[]
+        var aggregateColumns = new (string Header, string Range, string AggregateFunction)[]
         {
-            (SheetsConfig.HeaderNames.Pay, tripSheet.GetRange(SheetsConfig.HeaderNames.Pay, 2)),
-            (SheetsConfig.HeaderNames.Tips, tripSheet.GetRange(SheetsConfig.HeaderNames.Tips, 2)),
-            (SheetsConfig.HeaderNames.Bonus, tripSheet.GetRange(SheetsConfig.HeaderNames.Bonus, 2)),
-            (SheetsConfig.HeaderNames.Total, tripSheet.GetRange(SheetsConfig.HeaderNames.Total, 2)),
-            (SheetsConfig.HeaderNames.Distance, tripSheet.GetRange(SheetsConfig.HeaderNames.Distance, 2))
+            (SheetsConfig.HeaderNames.Pay, tripSheet.GetRange(SheetsConfig.HeaderNames.Pay, 2), "sum"),
+            (SheetsConfig.HeaderNames.Tips, tripSheet.GetRange(SheetsConfig.HeaderNames.Tips, 2), "sum"),
+            (SheetsConfig.HeaderNames.Bonus, tripSheet.GetRange(SheetsConfig.HeaderNames.Bonus, 2), "sum"),
+            (SheetsConfig.HeaderNames.Total, tripSheet.GetRange(SheetsConfig.HeaderNames.Total, 2), "sum"),
+            (SheetsConfig.HeaderNames.Distance, tripSheet.GetRange(SheetsConfig.HeaderNames.Distance, 2), "sum"),
+            (SheetsConfig.HeaderNames.VisitFirst, dateRange, "min"),
+            (SheetsConfig.HeaderNames.VisitLast, dateRange, "max")
         };
 
         var query = GoogleFormulaBuilder.BuildQueryGroupTwoColumns(
@@ -39,7 +43,7 @@ public static class LocationMapper
             placeRange,
             addressRange,
             SheetsConfig.HeaderNames.Trips,
-            sumColumns,
+            aggregateColumns,
             countColumnIsSecond: true);
 
         if (sheet.Headers.Count > 0)
@@ -47,17 +51,34 @@ public static class LocationMapper
             sheet.Headers[0].Formula = query;
         }
 
-        // Amt/Trip and Amt/Dist are derived from the sheet's own spilled Trips/Total/Distance columns,
-        // so they're separate self-referencing ARRAYFORMULAs rather than part of the QUERY spill.
+        var firstTripHeader = sheet.Headers.FirstOrDefault(h => h.Name == SheetsConfig.HeaderNames.VisitFirst);
+        if (firstTripHeader != null)
+        {
+            firstTripHeader.Format = FormatEnum.DATE;
+        }
+
+        var lastTripHeader = sheet.Headers.FirstOrDefault(h => h.Name == SheetsConfig.HeaderNames.VisitLast);
+        if (lastTripHeader != null)
+        {
+            lastTripHeader.Format = FormatEnum.DATE;
+        }
+
+        // Amt/Trip and Amt/Dist are derived from the sheet's own spilled Trips/Total/Distance
+        // columns, so they're separate self-referencing ARRAYFORMULAs rather than part of the
+        // QUERY spill (a QUERY's spilled array is contiguous - it can't leave gaps for other
+        // formulas in the middle and resume after, so they have to come after everything the
+        // query itself produces, including First Trip/Last Trip).
         // EnsureHeaderPlaceholders(1) marks every header past index 0 as HideHeaderName, which also
         // suppresses writing the cell's UserEnteredValue entirely (see SheetHelpers.HeadersToRowData) -
-        // these two headers need that flag cleared or their formulas never make it onto the sheet.
+        // these headers need that flag cleared or their formulas never make it onto the sheet.
+        var placeKeyRange = sheet.GetLocalRange(SheetsConfig.HeaderNames.Place);
+
         var amountPerTripHeader = sheet.Headers.FirstOrDefault(h => h.Name == SheetsConfig.HeaderNames.AmountPerTrip);
         if (amountPerTripHeader != null)
         {
             amountPerTripHeader.HideHeaderName = false;
             amountPerTripHeader.Formula = GigFormulaBuilder.BuildArrayFormulaAmountPerTrip(
-                sheet.GetLocalRange(SheetsConfig.HeaderNames.Place),
+                placeKeyRange,
                 SheetsConfig.HeaderNames.AmountPerTrip,
                 sheet.GetLocalRange(SheetsConfig.HeaderNames.Total),
                 sheet.GetLocalRange(SheetsConfig.HeaderNames.Trips));
@@ -68,7 +89,7 @@ public static class LocationMapper
         {
             amountPerDistanceHeader.HideHeaderName = false;
             amountPerDistanceHeader.Formula = GigFormulaBuilder.BuildArrayFormulaAmountPerDistance(
-                sheet.GetLocalRange(SheetsConfig.HeaderNames.Place),
+                placeKeyRange,
                 SheetsConfig.HeaderNames.AmountPerDistance,
                 sheet.GetLocalRange(SheetsConfig.HeaderNames.Total),
                 sheet.GetLocalRange(SheetsConfig.HeaderNames.Distance));

--- a/RaptorSheets.Gig/README.md
+++ b/RaptorSheets.Gig/README.md
@@ -182,8 +182,8 @@ Business expense tracking:
 ### Summary Helpers
 These sheets provide aggregated summaries derived from the `Trips` data. They are generated using query formulas in the mappers and are typically protected/read-only.
 
-- **Deliveries**: Aggregates trips by `Name` and `Address` into `Name | Address | Trips | Pay | Tips | Bonus | Total | Dist | Amt/Trip | Amt/Dist`. Implemented by `DeliveryMapper` and exposed via `SheetsConfig.Deliveries`.
-- **Locations**: Aggregates trips by `Place` and `Address` into `Place | Address | Trips | Pay | Tips | Bonus | Total | Dist | Amt/Trip | Amt/Dist`. Implemented by `LocationMapper` and exposed via `SheetsConfig.Locations`.
+- **Deliveries**: Aggregates trips by `Name` and `Address` into `Name | Address | Trips | Pay | Tips | Bonus | Total | Dist | First Trip | Last Trip | Amt/Trip | Amt/Dist`. Implemented by `DeliveryMapper` and exposed via `SheetsConfig.Deliveries`.
+- **Locations**: Aggregates trips by `Place` and `Address` into `Place | Address | Trips | Pay | Tips | Bonus | Total | Dist | First Trip | Last Trip | Amt/Trip | Amt/Dist`. Implemented by `LocationMapper` and exposed via `SheetsConfig.Locations`.
 
 These summary sheets are created as part of the normal sheet creation flow (`CreateAllSheets`) when present in the `SheetsConfig.SheetUtilities.GetAllSheetNames()` ordering.
 
@@ -330,6 +330,8 @@ public class DeliveryEntity
     public decimal? Bonus { get; set; }
     public decimal? Total { get; set; }
     public decimal? Distance { get; set; }
+    public string FirstTrip { get; set; } = "";
+    public string LastTrip { get; set; } = "";
     public decimal AmountPerTrip { get; set; }
     public decimal AmountPerDistance { get; set; }
 }
@@ -347,6 +349,8 @@ public class LocationEntity
     public decimal? Bonus { get; set; }
     public decimal? Total { get; set; }
     public decimal? Distance { get; set; }
+    public string FirstTrip { get; set; } = "";
+    public string LastTrip { get; set; } = "";
     public decimal AmountPerTrip { get; set; }
     public decimal AmountPerDistance { get; set; }
 }


### PR DESCRIPTION
Extends BuildQueryGroupTwoColumns to support arbitrary aggregate functions (sum/min/max) per column, and uses min/max on Trips.Date to compute First Trip and Last Trip within the same grouping QUERY used for Pay/Tips/Bonus/Total/Dist. Column order: Name/Place | Address | Trips | Pay | Tips | Bonus | Total | Dist | First Trip | Last Trip | Amt/Trip | Amt/Dist.