### PR TITLE
Refactor/shared manager base and sheet registry

### DIFF
--- a/RaptorSheets.Core.Tests/Unit/Helpers/ColumnInsertionHelperTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/ColumnInsertionHelperTests.cs
@@ -1,0 +1,125 @@
+using Google.Apis.Sheets.v4.Data;
+using Moq;
+using RaptorSheets.Core.Entities;
+using RaptorSheets.Core.Helpers;
+using RaptorSheets.Core.Models;
+using RaptorSheets.Core.Services;
+using Xunit;
+
+namespace RaptorSheets.Core.Tests.Unit.Helpers;
+
+public class ColumnInsertionHelperTests
+{
+    // Minimal ISheetEntity implementation - Core.Tests can't reference a real domain SheetEntity.
+    private class TestSheetEntity : ISheetEntity
+    {
+        public PropertyEntity Properties { get; set; } = new();
+        public List<MessageEntity> Messages { get; set; } = [];
+    }
+
+    [Fact]
+    public void BuildInsertRequests_WithSingleMissingColumn_BuildsInsertAndUpdateRequests()
+    {
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Widgets"] = [new ColumnInsertionInfo { SheetName = "Widgets", SheetId = 5, ColumnIndex = 2, ColumnName = "Price", ColumnLetter = "C" }]
+        };
+
+        var requests = ColumnInsertionHelper.BuildInsertRequests(missingColumns);
+
+        Assert.Equal(2, requests.Count);
+        var insertRequest = requests[0];
+        Assert.NotNull(insertRequest.InsertDimension);
+        Assert.Equal(5, insertRequest.InsertDimension.Range.SheetId);
+        Assert.Equal(2, insertRequest.InsertDimension.Range.StartIndex);
+        Assert.Equal(3, insertRequest.InsertDimension.Range.EndIndex);
+
+        var updateRequest = requests[1];
+        Assert.NotNull(updateRequest.UpdateCells);
+        Assert.Equal(2, updateRequest.UpdateCells.Range.StartColumnIndex);
+        Assert.Equal("Price", updateRequest.UpdateCells.Rows[0].Values[0].UserEnteredValue.StringValue);
+    }
+
+    [Fact]
+    public void BuildInsertRequests_WithMultipleMissingColumnsInOneSheet_InsertsRightToLeft()
+    {
+        // Inserting right-to-left (highest index first) so earlier insertions in the batch
+        // don't shift the index of columns still waiting to be inserted.
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Widgets"] =
+            [
+                new ColumnInsertionInfo { SheetName = "Widgets", SheetId = 1, ColumnIndex = 0, ColumnName = "First" },
+                new ColumnInsertionInfo { SheetName = "Widgets", SheetId = 1, ColumnIndex = 3, ColumnName = "Fourth" },
+                new ColumnInsertionInfo { SheetName = "Widgets", SheetId = 1, ColumnIndex = 1, ColumnName = "Second" }
+            ]
+        };
+
+        var requests = ColumnInsertionHelper.BuildInsertRequests(missingColumns);
+
+        // Each column produces 2 requests (insert + update); check the insert requests' order
+        var insertIndices = requests
+            .Where(r => r.InsertDimension != null)
+            .Select(r => r.InsertDimension.Range.StartIndex)
+            .ToList();
+
+        Assert.Equal([3, 1, 0], insertIndices);
+    }
+
+    [Fact]
+    public void BuildInsertRequests_WithNoMissingColumns_ReturnsEmptyList()
+    {
+        var requests = ColumnInsertionHelper.BuildInsertRequests([]);
+
+        Assert.Empty(requests);
+    }
+
+    [Fact]
+    public async Task InsertMissingColumnsAsync_WithNoMissingColumns_ReturnsInfoMessageWithoutCallingService()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+
+        var result = await ColumnInsertionHelper.InsertMissingColumnsAsync<TestSheetEntity>(mockService.Object, []);
+
+        Assert.Contains(result.Messages, m => m.Message.Contains("No missing columns to insert"));
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InsertMissingColumnsAsync_OnSuccess_ReturnsSuccessMessageAndCallsService()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        mockService
+            .Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>()))
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Widgets"] = [new ColumnInsertionInfo { SheetName = "Widgets", SheetId = 1, ColumnIndex = 0, ColumnName = "Price" }]
+        };
+
+        var result = await ColumnInsertionHelper.InsertMissingColumnsAsync<TestSheetEntity>(mockService.Object, missingColumns);
+
+        Assert.Contains(result.Messages, m => m.Message.Contains("Inserting column 'Price'"));
+        Assert.Contains(result.Messages, m => m.Message.Contains("Successfully inserted 1 missing column(s)"));
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task InsertMissingColumnsAsync_WhenServiceReturnsNull_ReturnsErrorMessage()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        mockService
+            .Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>()))
+            .ReturnsAsync((BatchUpdateSpreadsheetResponse?)null);
+
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Widgets"] = [new ColumnInsertionInfo { SheetName = "Widgets", SheetId = 1, ColumnIndex = 0, ColumnName = "Price" }]
+        };
+
+        var result = await ColumnInsertionHelper.InsertMissingColumnsAsync<TestSheetEntity>(mockService.Object, missingColumns);
+
+        Assert.Contains(result.Messages, m => m.Message.Contains("Failed to insert missing columns"));
+    }
+}

--- a/RaptorSheets.Core.Tests/Unit/Helpers/GoogleRequestHelpersTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/GoogleRequestHelpersTests.cs
@@ -516,4 +516,64 @@ public class GoogleRequestHelpersTests
         Assert.Equal(sheetId, request.UpdateSheetProperties.Properties.SheetId);
         Assert.Equal(index, request.UpdateSheetProperties.Properties.Index);
     }
+
+    [Fact]
+    public void GenerateInsertColumnDimension_BuildsColumnsInsertRequest()
+    {
+        // Arrange
+        var sheetId = 7;
+        var startIndex = 3;
+        var endIndex = 4;
+
+        // Act
+        var request = GoogleRequestHelpers.GenerateInsertColumnDimension(sheetId, startIndex, endIndex);
+
+        // Assert
+        Assert.NotNull(request.InsertDimension);
+        Assert.Equal("COLUMNS", request.InsertDimension.Range.Dimension);
+        Assert.Equal(sheetId, request.InsertDimension.Range.SheetId);
+        Assert.Equal(startIndex, request.InsertDimension.Range.StartIndex);
+        Assert.Equal(endIndex, request.InsertDimension.Range.EndIndex);
+        Assert.True(request.InsertDimension.InheritFromBefore);
+    }
+
+    [Fact]
+    public void GenerateInsertColumnDimension_WithInheritFromBeforeFalse_SetsFlagFalse()
+    {
+        var request = GoogleRequestHelpers.GenerateInsertColumnDimension(1, 0, 1, inheritFromBefore: false);
+
+        Assert.False(request.InsertDimension.InheritFromBefore);
+    }
+
+    [Fact]
+    public void GenerateUpdateCellsRequest_DefaultStartColumn_TargetsColumnZero()
+    {
+        // Arrange
+        var rows = new List<RowData> { new() { Values = [new CellData(), new CellData()] } };
+
+        // Act
+        var request = GoogleRequestHelpers.GenerateUpdateCellsRequest(sheetId: 5, rowIndex: 2, rows: rows);
+
+        // Assert
+        Assert.NotNull(request.UpdateCells);
+        Assert.Equal(0, request.UpdateCells.Range.StartColumnIndex);
+        Assert.Equal(2, request.UpdateCells.Range.EndColumnIndex);
+        Assert.Equal(2, request.UpdateCells.Range.StartRowIndex);
+        Assert.Equal(3, request.UpdateCells.Range.EndRowIndex);
+    }
+
+    [Fact]
+    public void GenerateUpdateCellsRequest_WithStartColumnIndex_TargetsThatColumn()
+    {
+        // Arrange - a single-cell row being written at a specific inserted column position
+        var rows = new List<RowData> { new() { Values = [new CellData()] } };
+
+        // Act
+        var request = GoogleRequestHelpers.GenerateUpdateCellsRequest(sheetId: 5, rowIndex: 0, rows: rows, startColumnIndex: 4);
+
+        // Assert - this is the fix for the original ported implementation, which always wrote to
+        // column 0 regardless of where the column was actually inserted
+        Assert.Equal(4, request.UpdateCells.Range.StartColumnIndex);
+        Assert.Equal(5, request.UpdateCells.Range.EndColumnIndex);
+    }
 }

--- a/RaptorSheets.Core.Tests/Unit/Helpers/HeaderHelpersTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/HeaderHelpersTests.cs
@@ -1,5 +1,6 @@
 using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Models.Google;
+using System.Linq;
 using Xunit;
 
 namespace RaptorSheets.Core.Tests.Unit.Helpers;
@@ -432,5 +433,90 @@ public class HeaderHelpersTests
 
         // Assert
         Assert.Equal("", result);
+    }
+
+    // CheckSheetHeaders(values, sheetModel, out insertionInfo) - missing-column detection used by
+    // the column auto-insertion feature (RaptorSheets.Core.Helpers.ColumnInsertionHelper).
+
+    [Fact]
+    public void CheckSheetHeaders_WithMissingColumn_ShouldReportInsertionInfoAtExpectedIndex()
+    {
+        // Arrange - "Header2" is missing entirely
+        var values = new List<object> { "Header1", "Header3" };
+        var sheetModel = new SheetModel
+        {
+            Name = "TestSheet",
+            Headers =
+            [
+                new SheetCellModel { Name = "Header1" },
+                new SheetCellModel { Name = "Header2" },
+                new SheetCellModel { Name = "Header3" }
+            ]
+        };
+
+        // Act
+        var messages = HeaderHelpers.CheckSheetHeaders(values, sheetModel, out var insertionInfo);
+
+        // Assert
+        Assert.Single(insertionInfo);
+        Assert.Equal("Header2", insertionInfo[0].ColumnName);
+        Assert.Equal(1, insertionInfo[0].ColumnIndex);
+        Assert.Equal("TestSheet", insertionInfo[0].SheetName);
+        Assert.Equal(0, insertionInfo[0].SheetId); // caller fills this in from spreadsheet metadata
+        Assert.Contains(messages, m => m.Message.Contains("Missing column [Header2]") && m.Message.Contains("can be inserted"));
+    }
+
+    [Fact]
+    public void CheckSheetHeaders_WithNoMissingColumns_ShouldReturnEmptyInsertionInfo()
+    {
+        var values = new List<object> { "Header1", "Header2" };
+        var sheetModel = new SheetModel
+        {
+            Name = "TestSheet",
+            Headers = [new SheetCellModel { Name = "Header1" }, new SheetCellModel { Name = "Header2" }]
+        };
+
+        var messages = HeaderHelpers.CheckSheetHeaders(values, sheetModel, out var insertionInfo);
+
+        Assert.Empty(insertionInfo);
+        Assert.Empty(messages);
+    }
+
+    [Fact]
+    public void CheckSheetHeaders_WithMultipleMissingColumns_ShouldReportEachAtItsOwnIndex()
+    {
+        var values = new List<object> { "Header2" };
+        var sheetModel = new SheetModel
+        {
+            Name = "TestSheet",
+            Headers =
+            [
+                new SheetCellModel { Name = "Header1" },
+                new SheetCellModel { Name = "Header2" },
+                new SheetCellModel { Name = "Header3" }
+            ]
+        };
+
+        HeaderHelpers.CheckSheetHeaders(values, sheetModel, out var insertionInfo);
+
+        Assert.Equal(2, insertionInfo.Count);
+        Assert.Contains(insertionInfo, i => i.ColumnName == "Header1" && i.ColumnIndex == 0);
+        Assert.Contains(insertionInfo, i => i.ColumnName == "Header3" && i.ColumnIndex == 2);
+    }
+
+    [Fact]
+    public void CheckSheetHeaders_TwoArgOverload_StillWorksWithoutInsertionInfo()
+    {
+        // The original two-arg overload must remain unaffected by adding the out-param version
+        var values = new List<object> { "Header1" };
+        var sheetModel = new SheetModel
+        {
+            Name = "TestSheet",
+            Headers = [new SheetCellModel { Name = "Header1" }, new SheetCellModel { Name = "Header2" }]
+        };
+
+        var messages = HeaderHelpers.CheckSheetHeaders(values, sheetModel);
+
+        Assert.Contains(messages, m => m.Message.Contains("Missing column [Header2]"));
     }
 }

--- a/RaptorSheets.Core.Tests/Unit/Helpers/HeaderHelpersTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/HeaderHelpersTests.cs
@@ -519,4 +519,40 @@ public class HeaderHelpersTests
 
         Assert.Contains(messages, m => m.Message.Contains("Missing column [Header2]"));
     }
+
+    // HideHeaderName columns (e.g. Delivery/Location's "First Trip"/"Last Trip") are populated by
+    // a spilling QUERY formula placed in an earlier header cell, not written as their own
+    // standalone cell - they must never be treated as insertable, since a physical column insert
+    // would land inside the query's contiguous spill range and break it.
+
+    [Fact]
+    public void CheckSheetHeaders_WithMissingHideHeaderNameColumn_ShouldNotAddToInsertionInfo()
+    {
+        // Arrange - "QueryLabel" is missing and marked HideHeaderName (populated by a spilling
+        // QUERY elsewhere on the sheet), "Regular" is missing and is a normal column
+        var values = new List<object> { "Header1" };
+        var sheetModel = new SheetModel
+        {
+            Name = "TestSheet",
+            Headers =
+            [
+                new SheetCellModel { Name = "Header1" },
+                new SheetCellModel { Name = "QueryLabel", HideHeaderName = true },
+                new SheetCellModel { Name = "Regular" }
+            ]
+        };
+
+        // Act
+        var messages = HeaderHelpers.CheckSheetHeaders(values, sheetModel, out var insertionInfo);
+
+        // Assert - only the regular column is a candidate for insertion
+        Assert.Single(insertionInfo);
+        Assert.Equal("Regular", insertionInfo[0].ColumnName);
+        Assert.DoesNotContain(insertionInfo, i => i.ColumnName == "QueryLabel");
+
+        // The HideHeaderName column still gets reported as missing, but without the
+        // "can be inserted" claim, since it isn't one
+        Assert.Contains(messages, m => m.Message.Contains("Missing column [QueryLabel]") && !m.Message.Contains("can be inserted"));
+        Assert.Contains(messages, m => m.Message.Contains("Missing column [Regular] - can be inserted"));
+    }
 }

--- a/RaptorSheets.Core.Tests/Unit/Managers/GoogleSheetManagerBaseTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Managers/GoogleSheetManagerBaseTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using RaptorSheets.Core.Managers;
+using RaptorSheets.Core.Services;
+using Xunit;
+
+namespace RaptorSheets.Core.Tests.Unit.Managers;
+
+public class GoogleSheetManagerBaseTests
+{
+    // Minimal concrete subclass to exercise the abstract base's constructors/fields, mirroring
+    // how RaptorSheets.Gig/Stock's GoogleSheetManager classes now inherit from it.
+    private class TestGoogleSheetManager : GoogleSheetManagerBase
+    {
+        public TestGoogleSheetManager(IGoogleSheetService service, ILogger? logger = null) : base(service, logger) { }
+        public TestGoogleSheetManager(string accessToken, string spreadsheetId, ILogger? logger = null) : base(accessToken, spreadsheetId, logger) { }
+        public TestGoogleSheetManager(Dictionary<string, string> parameters, string spreadsheetId, ILogger? logger = null) : base(parameters, spreadsheetId, logger) { }
+
+        public IGoogleSheetService ServiceForTest => _googleSheetService;
+        public ILogger LoggerForTest => _logger;
+    }
+
+    [Fact]
+    public void Constructor_WithService_ShouldAssignService()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+
+        var manager = new TestGoogleSheetManager(mockService.Object);
+
+        Assert.Same(mockService.Object, manager.ServiceForTest);
+    }
+
+    [Fact]
+    public void Constructor_WithNullService_ShouldThrowArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new TestGoogleSheetManager((IGoogleSheetService)null!));
+    }
+
+    [Fact]
+    public void Constructor_WithoutLogger_ShouldDefaultToNullLogger()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+
+        var manager = new TestGoogleSheetManager(mockService.Object);
+
+        Assert.NotNull(manager.LoggerForTest);
+        Assert.IsType<NullLogger>(manager.LoggerForTest);
+    }
+
+    [Fact]
+    public void Constructor_WithLogger_ShouldUseProvidedLogger()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        var mockLogger = new Mock<ILogger>();
+
+        var manager = new TestGoogleSheetManager(mockService.Object, mockLogger.Object);
+
+        Assert.Same(mockLogger.Object, manager.LoggerForTest);
+    }
+
+    [Fact]
+    public void Constructor_WithAccessTokenAndSpreadsheetId_ShouldInitializeWithoutThrowing()
+    {
+        var manager = new TestGoogleSheetManager("test-token", "test-spreadsheet-id");
+
+        Assert.NotNull(manager.ServiceForTest);
+        Assert.NotNull(manager.LoggerForTest);
+    }
+
+    [Fact]
+    public void Constructor_WithParametersDictionaryAndSpreadsheetId_ShouldInitializeWithoutThrowing()
+    {
+        // Minimal fake service-account parameters; we only verify construction, not a live call
+        var parameters = new Dictionary<string, string>
+        {
+            { "type", "service_account" },
+            { "privateKeyId", "fake-key-id" },
+            { "privateKey", "-----BEGIN PRIVATE KEY-----\\nMIIB...fake...\\n-----END PRIVATE KEY-----\\n" },
+            { "clientEmail", "test@example.com" },
+            { "clientId", "123" }
+        };
+
+        var manager = new TestGoogleSheetManager(parameters, "test-spreadsheet-id");
+
+        Assert.NotNull(manager.ServiceForTest);
+        Assert.NotNull(manager.LoggerForTest);
+    }
+}

--- a/RaptorSheets.Core.Tests/Unit/Registries/SheetRegistryTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Registries/SheetRegistryTests.cs
@@ -1,0 +1,255 @@
+using Google.Apis.Sheets.v4.Data;
+using RaptorSheets.Core.Attributes;
+using RaptorSheets.Core.Entities;
+using RaptorSheets.Core.Models.Google;
+using RaptorSheets.Core.Registries;
+using Xunit;
+
+namespace RaptorSheets.Core.Tests.Unit.Registries;
+
+public class SheetRegistryTests
+{
+    // Minimal ISheetEntity implementation, standing in for a domain's real SheetEntity
+    // (RaptorSheets.Gig.Entities.SheetEntity / RaptorSheets.Stock.Entities.SheetEntity), which
+    // Core.Tests can't reference directly.
+    private class TestSheetEntity : ISheetEntity
+    {
+        public PropertyEntity Properties { get; set; } = new();
+        public List<MessageEntity> Messages { get; set; } = [];
+        public List<TestRowEntity> Widgets { get; set; } = [];
+    }
+
+    private class TestRowEntity
+    {
+        public int RowId { get; set; }
+
+        [Column("Name", isInput: true)]
+        public string Name { get; set; } = "";
+    }
+
+    private static SheetModel TestSheetModel() => new()
+    {
+        Name = "Widgets",
+        Headers = [new SheetCellModel { Name = "Name" }]
+    };
+
+    private static BatchGetValuesByDataFilterResponse BuildBatchResponse(string sheetName, IList<object> headerRow, IList<object>? dataRow = null)
+    {
+        var values = new List<IList<object>> { headerRow };
+        if (dataRow != null)
+        {
+            values.Add(dataRow);
+        }
+
+        return new BatchGetValuesByDataFilterResponse
+        {
+            ValueRanges =
+            [
+                new MatchedValueRange
+                {
+                    DataFilters = [new DataFilter { A1Range = sheetName }],
+                    ValueRange = new ValueRange { Values = values }
+                }
+            ]
+        };
+    }
+
+    [Fact]
+    public void Register_ThenIsRegistered_ShouldReturnTrue()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+
+        registry.Register("Widgets", TestSheetModel, (_, _) => { });
+
+        Assert.True(registry.IsRegistered("Widgets"));
+        Assert.False(registry.IsRegistered("Unknown"));
+    }
+
+    [Fact]
+    public void Register_IsCaseInsensitive()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+
+        registry.Register("Widgets", TestSheetModel, (_, _) => { });
+
+        Assert.True(registry.IsRegistered("widgets"));
+        Assert.True(registry.IsRegistered("WIDGETS"));
+    }
+
+    [Fact]
+    public void Register_WithNullFactoryOrProcessor_ShouldThrow()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+
+        Assert.Throws<ArgumentNullException>(() => registry.Register("Widgets", null!, (_, _) => { }));
+        Assert.Throws<ArgumentNullException>(() => registry.Register("Widgets", TestSheetModel, null!));
+    }
+
+    [Fact]
+    public void MapData_BatchResponse_WithNullValueRanges_ShouldReturnNull()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        var response = new BatchGetValuesByDataFilterResponse { ValueRanges = null };
+
+        var result = registry.MapData(response);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void MapData_BatchResponse_WithRegisteredSheet_ShouldInvokeProcessor()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModel, (entity, values) =>
+        {
+            entity.Widgets = [new TestRowEntity { Name = values[1][0].ToString()! }];
+        });
+
+        var response = BuildBatchResponse("Widgets", ["Name"], ["Sprocket"]);
+
+        var result = registry.MapData(response);
+
+        Assert.NotNull(result);
+        Assert.Single(result.Widgets);
+        Assert.Equal("Sprocket", result.Widgets[0].Name);
+    }
+
+    [Fact]
+    public void MapData_BatchResponse_WithUnregisteredSheetName_ShouldBeIgnored()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModel, (_, _) => throw new InvalidOperationException("should not be called"));
+
+        var response = BuildBatchResponse("SomeOtherSheet", ["Name"], ["Sprocket"]);
+
+        var result = registry.MapData(response);
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Widgets);
+    }
+
+    [Fact]
+    public void MapData_BatchResponse_WithEmptyValues_ShouldSkipProcessor()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        var wasCalled = false;
+        registry.Register("Widgets", TestSheetModel, (_, _) => wasCalled = true);
+
+        var response = new BatchGetValuesByDataFilterResponse
+        {
+            ValueRanges =
+            [
+                new MatchedValueRange
+                {
+                    DataFilters = [new DataFilter { A1Range = "Widgets" }],
+                    ValueRange = new ValueRange { Values = new List<IList<object>>() }
+                }
+            ]
+        };
+
+        registry.MapData(response);
+
+        Assert.False(wasCalled);
+    }
+
+    [Fact]
+    public void MapData_Spreadsheet_ShouldSetPropertiesNameAndInvokeProcessor()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModel, (entity, values) =>
+        {
+            entity.Widgets = [new TestRowEntity { Name = values[1][0].ToString()! }];
+        });
+
+        var spreadsheet = new Spreadsheet
+        {
+            Properties = new SpreadsheetProperties { Title = "MySpreadsheet" },
+            Sheets =
+            [
+                new Sheet
+                {
+                    Properties = new SheetProperties { Title = "Widgets" },
+                    Data =
+                    [
+                        new GridData
+                        {
+                            RowData =
+                            [
+                                new RowData { Values = [new CellData { FormattedValue = "Name" }] },
+                                new RowData { Values = [new CellData { FormattedValue = "Sprocket" }] }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var result = registry.MapData(spreadsheet);
+
+        Assert.Equal("MySpreadsheet", result.Properties.Name);
+        Assert.Single(result.Widgets);
+        Assert.Equal("Sprocket", result.Widgets[0].Name);
+    }
+
+    [Fact]
+    public void GetMissingSheets_WithSheetNotInSpreadsheet_ShouldReturnItsSheetModel()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModel, (_, _) => { });
+
+        var spreadsheet = new Spreadsheet { Sheets = [] };
+
+        var missing = registry.GetMissingSheets(spreadsheet, ["Widgets"]);
+
+        Assert.Single(missing);
+        Assert.Equal("Widgets", missing[0].Name);
+    }
+
+    [Fact]
+    public void GetMissingSheets_WithSheetAlreadyPresent_ShouldNotReturnIt()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModel, (_, _) => { });
+
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets = [new Sheet { Properties = new SheetProperties { Title = "widgets" } }]
+        };
+
+        var missing = registry.GetMissingSheets(spreadsheet, ["Widgets"]);
+
+        Assert.Empty(missing);
+    }
+
+    [Fact]
+    public void RegisterGeneric_ShouldCheckHeadersAndMapRowsViaGenericSheetMapper()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+
+        registry.RegisterGeneric<TestSheetEntity, TestRowEntity>("Widgets", TestSheetModel, (entity, rows) => entity.Widgets = rows);
+
+        var response = BuildBatchResponse("Widgets", ["Name"], ["Sprocket"]);
+
+        var result = registry.MapData(response);
+
+        Assert.NotNull(result);
+        Assert.Single(result.Widgets);
+        Assert.Equal("Sprocket", result.Widgets[0].Name);
+        Assert.Equal(2, result.Widgets[0].RowId);
+    }
+
+    [Fact]
+    public void RegisterGeneric_WithMismatchedHeader_ShouldAddHeaderCheckMessage()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.RegisterGeneric<TestSheetEntity, TestRowEntity>("Widgets", TestSheetModel, (entity, rows) => entity.Widgets = rows);
+
+        // "WrongHeader" doesn't match the expected "Name" header from TestSheetModel
+        var response = BuildBatchResponse("Widgets", ["WrongHeader"], ["Sprocket"]);
+
+        var result = registry.MapData(response);
+
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Messages);
+    }
+}

--- a/RaptorSheets.Core.Tests/Unit/Registries/SheetRegistryTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Registries/SheetRegistryTests.cs
@@ -252,4 +252,137 @@ public class SheetRegistryTests
         Assert.NotNull(result);
         Assert.NotEmpty(result.Messages);
     }
+
+    [Fact]
+    public void CheckUnknownSheets_WithNullSpreadsheet_ShouldReturnErrorMessage()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+
+        var result = registry.CheckUnknownSheets(null!);
+
+        Assert.Single(result);
+        Assert.Contains("Unable to retrieve sheet(s)", result[0].Message);
+    }
+
+    [Fact]
+    public void CheckUnknownSheets_WithUnregisteredTab_ShouldWarn()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModel, (_, _) => { });
+
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new Sheet { Properties = new SheetProperties { Title = "Widgets" } },
+                new Sheet { Properties = new SheetProperties { Title = "Gadgets" } }
+            ]
+        };
+
+        var result = registry.CheckUnknownSheets(spreadsheet);
+
+        Assert.Contains(result, m => m.Message.Contains("Gadgets") && m.Message.Contains("does not match any known sheet name"));
+    }
+
+    [Fact]
+    public void CheckSheetHeaders_WithNullSpreadsheet_ShouldReturnErrorMessage()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+
+        var result = registry.CheckSheetHeaders(null!);
+
+        Assert.Single(result);
+        Assert.Contains("Unable to retrieve sheet(s)", result[0].Message);
+    }
+
+    [Fact]
+    public void CheckSheetHeaders_WithMatchingHeader_ShouldReportNoIssues()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModel, (_, _) => { });
+
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new Sheet
+                {
+                    Properties = new SheetProperties { Title = "Widgets" },
+                    Data =
+                    [
+                        new GridData
+                        {
+                            RowData = [new RowData { Values = [new CellData { FormattedValue = "Name" }] }]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var result = registry.CheckSheetHeaders(spreadsheet);
+
+        Assert.Contains(result, m => m.Message.Contains("No sheet header issues found"));
+    }
+
+    [Fact]
+    public void CheckSheetHeaders_WithMismatchedHeader_ShouldReportIssue()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModel, (_, _) => { });
+
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new Sheet
+                {
+                    Properties = new SheetProperties { Title = "Widgets" },
+                    Data =
+                    [
+                        new GridData
+                        {
+                            RowData = [new RowData { Values = [new CellData { FormattedValue = "WrongHeader" }] }]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var result = registry.CheckSheetHeaders(spreadsheet);
+
+        Assert.Contains(result, m => m.Message.Contains("Found sheet header issue(s)"));
+    }
+
+    [Fact]
+    public void GetSheetLayout_WithRegisteredSheet_ReturnsModel()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModel, (_, _) => { });
+
+        var layout = registry.GetSheetLayout("Widgets");
+
+        Assert.NotNull(layout);
+        Assert.Equal("Widgets", layout.Name);
+    }
+
+    [Fact]
+    public void GetSheetLayout_WithUnknownSheet_ReturnsNull()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+
+        Assert.Null(registry.GetSheetLayout("Unknown"));
+        Assert.Null(registry.GetSheetLayout(""));
+    }
+
+    [Fact]
+    public void GetSheetLayouts_WithMixedNames_ReturnsOnlyRegistered()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModel, (_, _) => { });
+
+        var layouts = registry.GetSheetLayouts(["Widgets", "Unknown"]);
+
+        Assert.Single(layouts);
+        Assert.Equal("Widgets", layouts[0].Name);
+    }
 }

--- a/RaptorSheets.Core.Tests/Unit/Registries/SheetRegistryTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Registries/SheetRegistryTests.cs
@@ -385,4 +385,79 @@ public class SheetRegistryTests
         Assert.Single(layouts);
         Assert.Equal("Widgets", layouts[0].Name);
     }
+
+    // CheckSheetHeaders(spreadsheet, out missingColumns) - the overload that also detects columns
+    // missing entirely, for use with RaptorSheets.Core.Helpers.ColumnInsertionHelper.
+
+    private static SheetModel TestSheetModelWithTwoColumns() => new()
+    {
+        Name = "Widgets",
+        Headers = [new SheetCellModel { Name = "Name" }, new SheetCellModel { Name = "Price" }]
+    };
+
+    [Fact]
+    public void CheckSheetHeaders_OutParam_WithMissingColumn_PopulatesSheetIdFromSpreadsheet()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModelWithTwoColumns, (_, _) => { });
+
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new Sheet
+                {
+                    Properties = new SheetProperties { Title = "Widgets", SheetId = 99 },
+                    Data =
+                    [
+                        // Only "Name" present - "Price" is missing entirely
+                        new GridData { RowData = [new RowData { Values = [new CellData { FormattedValue = "Name" }] }] }
+                    ]
+                }
+            ]
+        };
+
+        var messages = registry.CheckSheetHeaders(spreadsheet, out var missingColumns);
+
+        Assert.True(missingColumns.ContainsKey("Widgets"));
+        var missing = Assert.Single(missingColumns["Widgets"]);
+        Assert.Equal("Price", missing.ColumnName);
+        Assert.Equal(1, missing.ColumnIndex);
+        Assert.Equal(99, missing.SheetId);
+        Assert.Contains(messages, m => m.Message.Contains("Found sheet header issue(s)"));
+    }
+
+    [Fact]
+    public void CheckSheetHeaders_OutParam_WithNoMissingColumns_ReturnsEmptyDictionary()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+        registry.Register("Widgets", TestSheetModel, (_, _) => { });
+
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new Sheet
+                {
+                    Properties = new SheetProperties { Title = "Widgets", SheetId = 1 },
+                    Data = [new GridData { RowData = [new RowData { Values = [new CellData { FormattedValue = "Name" }] }] }]
+                }
+            ]
+        };
+
+        registry.CheckSheetHeaders(spreadsheet, out var missingColumns);
+
+        Assert.Empty(missingColumns);
+    }
+
+    [Fact]
+    public void CheckSheetHeaders_OutParam_WithNullSpreadsheet_ReturnsEmptyDictionary()
+    {
+        var registry = new SheetRegistry<TestSheetEntity>();
+
+        var messages = registry.CheckSheetHeaders(null!, out var missingColumns);
+
+        Assert.Empty(missingColumns);
+        Assert.Single(messages);
+    }
 }

--- a/RaptorSheets.Core/Entities/ISheetEntity.cs
+++ b/RaptorSheets.Core/Entities/ISheetEntity.cs
@@ -1,0 +1,13 @@
+namespace RaptorSheets.Core.Entities;
+
+/// <summary>
+/// Minimal shape every domain's top-level SheetEntity (Gig, Stock, and future domains) already
+/// shares. Lets Core provide generic orchestration (see RaptorSheets.Core.Registries.SheetRegistry)
+/// over the common Properties/Messages fields without knowing anything about a domain's own
+/// strongly-typed row collections (Trips, Accounts, etc.).
+/// </summary>
+public interface ISheetEntity
+{
+    PropertyEntity Properties { get; set; }
+    List<MessageEntity> Messages { get; set; }
+}

--- a/RaptorSheets.Core/Helpers/ColumnInsertionHelper.cs
+++ b/RaptorSheets.Core/Helpers/ColumnInsertionHelper.cs
@@ -1,0 +1,98 @@
+using Google.Apis.Sheets.v4.Data;
+using RaptorSheets.Core.Entities;
+using RaptorSheets.Core.Enums;
+using RaptorSheets.Core.Models;
+using RaptorSheets.Core.Services;
+
+namespace RaptorSheets.Core.Helpers;
+
+/// <summary>
+/// Builds and executes the Google Sheets batch request that physically inserts columns detected
+/// as missing by <see cref="HeaderHelpers.CheckSheetHeaders(IList{object}, Models.Google.SheetModel, out List{ColumnInsertionInfo})"/>
+/// (via <see cref="Registries.SheetRegistry{TEntity}"/>). Generic over the domain's SheetEntity type
+/// so every domain package (Gig, Stock, and future ones) gets this for free.
+/// </summary>
+public static class ColumnInsertionHelper
+{
+    /// <summary>
+    /// Builds the InsertDimension + UpdateCells requests for every missing column, one sheet at a
+    /// time. Columns within a sheet are inserted right-to-left (highest index first) so earlier
+    /// insertions don't shift the index of columns still to be inserted.
+    /// </summary>
+    public static List<Request> BuildInsertRequests(Dictionary<string, List<ColumnInsertionInfo>> missingColumns)
+    {
+        var requests = new List<Request>();
+
+        foreach (var (_, columns) in missingColumns)
+        {
+            var sortedColumns = columns.OrderByDescending(c => c.ColumnIndex).ToList();
+
+            foreach (var column in sortedColumns)
+            {
+                requests.Add(GoogleRequestHelpers.GenerateInsertColumnDimension(
+                    column.SheetId,
+                    column.ColumnIndex,
+                    column.ColumnIndex + 1,
+                    inheritFromBefore: true));
+
+                var headerRow = new RowData
+                {
+                    Values = [new CellData { UserEnteredValue = new ExtendedValue { StringValue = column.ColumnName } }]
+                };
+
+                requests.Add(GoogleRequestHelpers.GenerateUpdateCellsRequest(
+                    column.SheetId,
+                    rowIndex: 0,
+                    rows: [headerRow],
+                    startColumnIndex: column.ColumnIndex));
+            }
+        }
+
+        return requests;
+    }
+
+    /// <summary>
+    /// Inserts every missing column described in <paramref name="missingColumns"/> in a single
+    /// batch request and returns a result entity describing what happened.
+    /// </summary>
+    public static async Task<TEntity> InsertMissingColumnsAsync<TEntity>(
+        IGoogleSheetService googleSheetService,
+        Dictionary<string, List<ColumnInsertionInfo>> missingColumns)
+        where TEntity : class, ISheetEntity, new()
+    {
+        var entity = new TEntity();
+
+        if (missingColumns == null || missingColumns.Count == 0)
+        {
+            entity.Messages.Add(MessageHelpers.CreateInfoMessage("No missing columns to insert", MessageTypeEnum.CHECK_SHEET));
+            return entity;
+        }
+
+        foreach (var (sheetName, columns) in missingColumns)
+        {
+            foreach (var column in columns)
+            {
+                entity.Messages.Add(MessageHelpers.CreateInfoMessage(
+                    $"Inserting column '{column.ColumnName}' at index {column.ColumnIndex} in sheet '{sheetName}'",
+                    MessageTypeEnum.CHECK_SHEET));
+            }
+        }
+
+        var requests = BuildInsertRequests(missingColumns);
+        var batchRequest = new BatchUpdateSpreadsheetRequest { Requests = requests };
+        var result = await googleSheetService.BatchUpdateSpreadsheet(batchRequest);
+
+        if (result != null)
+        {
+            entity.Messages.Add(MessageHelpers.CreateInfoMessage(
+                $"Successfully inserted {missingColumns.Sum(kv => kv.Value.Count)} missing column(s)",
+                MessageTypeEnum.CHECK_SHEET));
+        }
+        else
+        {
+            entity.Messages.Add(MessageHelpers.CreateErrorMessage("Failed to insert missing columns", MessageTypeEnum.CHECK_SHEET));
+        }
+
+        return entity;
+    }
+}

--- a/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
+++ b/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
@@ -228,6 +228,33 @@ public static class GoogleRequestHelpers
         return insertRequest;
     }
 
+    /// <summary>
+    /// Generates a request to insert one or more columns at a specific position.
+    /// </summary>
+    /// <param name="sheetId">The sheet ID to insert columns into.</param>
+    /// <param name="startIndex">The column index to start inserting at (0-based).</param>
+    /// <param name="endIndex">The column index to end inserting at (exclusive, 0-based).</param>
+    /// <param name="inheritFromBefore">If true, inherits formatting from the column before the insertion point.</param>
+    public static Request GenerateInsertColumnDimension(int sheetId, int startIndex, int endIndex, bool inheritFromBefore = true)
+    {
+        var insertRequest = new Request
+        {
+            InsertDimension = new InsertDimensionRequest
+            {
+                Range = new DimensionRange
+                {
+                    SheetId = sheetId,
+                    Dimension = "COLUMNS",
+                    StartIndex = startIndex,
+                    EndIndex = endIndex
+                },
+                InheritFromBefore = inheritFromBefore
+            }
+        };
+
+        return insertRequest;
+    }
+
     public static BatchGetValuesByDataFilterRequest GenerateBatchGetValuesByDataFilterRequest(List<string> sheets, string? range = "")
     {
         if (sheets == null || sheets.Count < 1)
@@ -332,7 +359,7 @@ public static class GoogleRequestHelpers
         return new Request { AddSheet = sheetRequest };
     }
 
-    public static Request GenerateUpdateCellsRequest(int sheetId, int rowIndex, IList<RowData> rows) 
+    public static Request GenerateUpdateCellsRequest(int sheetId, int rowIndex, IList<RowData> rows, int startColumnIndex = 0)
     {
         // Indexes are 1 less than rowIds
         var range = new GridRange
@@ -340,6 +367,8 @@ public static class GoogleRequestHelpers
             SheetId = sheetId,
             StartRowIndex = rowIndex,
             EndRowIndex = rowIndex + 1,
+            StartColumnIndex = startColumnIndex,
+            EndColumnIndex = startColumnIndex + rows.Max(r => r.Values?.Count ?? 0),
         };
 
         // Create Sheet Data

--- a/RaptorSheets.Core/Helpers/HeaderHelpers.cs
+++ b/RaptorSheets.Core/Helpers/HeaderHelpers.cs
@@ -233,15 +233,29 @@ public static class HeaderHelpers
 
             if (!values.Any(x => string.Equals(x?.ToString()?.Trim(), sheetHeader.Name, StringComparison.OrdinalIgnoreCase)))
             {
-                insertionInfo.Add(new ColumnInsertionInfo
+                // HideHeaderName columns are populated by a spilling QUERY formula placed in an
+                // earlier header cell (see SheetHelpers' use of the flag when writing headers) -
+                // they never have their own standalone header cell to insert, and physically
+                // inserting a column here would land inside the query's contiguous spill range
+                // and break it. They're also expected to read back empty whenever the sheet
+                // currently has no underlying rows for the query to spill, so this isn't
+                // necessarily a real problem - just never a candidate for insertion.
+                if (!sheetHeader.HideHeaderName)
                 {
-                    SheetName = sheetModel.Name,
-                    ColumnIndex = index,
-                    ColumnName = sheetHeader.Name,
-                    ColumnLetter = SheetHelpers.GetColumnName(index)
-                });
+                    insertionInfo.Add(new ColumnInsertionInfo
+                    {
+                        SheetName = sheetModel.Name,
+                        ColumnIndex = index,
+                        ColumnName = sheetHeader.Name,
+                        ColumnLetter = SheetHelpers.GetColumnName(index)
+                    });
 
-                messages.Add(MessageHelpers.CreateErrorMessage($"[{sheetColumn}]: Missing column [{sheetHeader.Name}] - can be inserted", MessageTypeEnum.CHECK_SHEET));
+                    messages.Add(MessageHelpers.CreateErrorMessage($"[{sheetColumn}]: Missing column [{sheetHeader.Name}] - can be inserted", MessageTypeEnum.CHECK_SHEET));
+                }
+                else
+                {
+                    messages.Add(MessageHelpers.CreateErrorMessage($"[{sheetColumn}]: Missing column [{sheetHeader.Name}]", MessageTypeEnum.CHECK_SHEET));
+                }
             }
             else
             {

--- a/RaptorSheets.Core/Helpers/HeaderHelpers.cs
+++ b/RaptorSheets.Core/Helpers/HeaderHelpers.cs
@@ -2,6 +2,7 @@ using Google.Apis.Sheets.v4.Data;
 using RaptorSheets.Core.Constants;
 using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Enums;
+using RaptorSheets.Core.Models;
 using RaptorSheets.Core.Models.Google;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
@@ -198,7 +199,22 @@ public static class HeaderHelpers
     
     public static List<MessageEntity> CheckSheetHeaders(IList<object> values, SheetModel sheetModel)
     {
+        return CheckSheetHeaders(values, sheetModel, out _);
+    }
+
+    /// <summary>
+    /// Checks sheet headers against the expected model and additionally reports which expected
+    /// columns are missing entirely (not found anywhere in the row), with the index/letter they
+    /// should be inserted at according to the model's canonical column order. Callers that don't
+    /// need auto-insertion can use the simpler overload above.
+    /// </summary>
+    /// <param name="values">Actual header values from the sheet</param>
+    /// <param name="sheetModel">Expected sheet model with header definitions</param>
+    /// <param name="insertionInfo">Output list of columns that need to be inserted (SheetId left at 0 - the caller fills that in from spreadsheet metadata)</param>
+    public static List<MessageEntity> CheckSheetHeaders(IList<object> values, SheetModel sheetModel, out List<ColumnInsertionInfo> insertionInfo)
+    {
         var messages = new List<MessageEntity>();
+        insertionInfo = [];
 
         // If there are no header values (sheet empty or header row missing), return a single, clear message
         if (values == null || values.Count == 0 || values.All(v => string.IsNullOrWhiteSpace(v?.ToString())))
@@ -217,7 +233,15 @@ public static class HeaderHelpers
 
             if (!values.Any(x => string.Equals(x?.ToString()?.Trim(), sheetHeader.Name, StringComparison.OrdinalIgnoreCase)))
             {
-                messages.Add(MessageHelpers.CreateErrorMessage($"[{sheetColumn}]: Missing column [{sheetHeader.Name}]", MessageTypeEnum.CHECK_SHEET));
+                insertionInfo.Add(new ColumnInsertionInfo
+                {
+                    SheetName = sheetModel.Name,
+                    ColumnIndex = index,
+                    ColumnName = sheetHeader.Name,
+                    ColumnLetter = SheetHelpers.GetColumnName(index)
+                });
+
+                messages.Add(MessageHelpers.CreateErrorMessage($"[{sheetColumn}]: Missing column [{sheetHeader.Name}] - can be inserted", MessageTypeEnum.CHECK_SHEET));
             }
             else
             {

--- a/RaptorSheets.Core/Managers/GoogleSheetManagerBase.cs
+++ b/RaptorSheets.Core/Managers/GoogleSheetManagerBase.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using RaptorSheets.Core.Services;
+
+namespace RaptorSheets.Core.Managers;
+
+/// <summary>
+/// Shared construction/plumbing for domain-specific Google Sheet managers (Gig, Stock, and future
+/// domains). Each domain package keeps its own manager class, its own public API shape, and its own
+/// strongly-typed entities/mappers - this only removes the duplicated constructor boilerplate
+/// (DI constructor + two convenience constructors + optional logger wiring) that would otherwise be
+/// hand-rolled identically in every domain package.
+/// </summary>
+public abstract class GoogleSheetManagerBase
+{
+    protected readonly IGoogleSheetService _googleSheetService;
+    protected readonly ILogger _logger;
+
+    protected GoogleSheetManagerBase(IGoogleSheetService googleSheetService, ILogger? logger = null)
+    {
+        _googleSheetService = googleSheetService ?? throw new ArgumentNullException(nameof(googleSheetService));
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    protected GoogleSheetManagerBase(string accessToken, string spreadsheetId, ILogger? logger = null)
+        : this(new GoogleSheetService(accessToken, spreadsheetId, logger), logger)
+    {
+    }
+
+    protected GoogleSheetManagerBase(Dictionary<string, string> parameters, string spreadsheetId, ILogger? logger = null)
+        : this(new GoogleSheetService(parameters, spreadsheetId, logger), logger)
+    {
+    }
+}

--- a/RaptorSheets.Core/Models/ColumnInsertionInfo.cs
+++ b/RaptorSheets.Core/Models/ColumnInsertionInfo.cs
@@ -1,0 +1,32 @@
+namespace RaptorSheets.Core.Models;
+
+/// <summary>
+/// Information about a column that needs to be inserted into a sheet.
+/// </summary>
+public class ColumnInsertionInfo
+{
+    /// <summary>
+    /// The name of the sheet where the column should be inserted.
+    /// </summary>
+    public string SheetName { get; set; } = "";
+
+    /// <summary>
+    /// The sheet ID from Google Sheets.
+    /// </summary>
+    public int SheetId { get; set; }
+
+    /// <summary>
+    /// The column index where the insertion should occur (0-based).
+    /// </summary>
+    public int ColumnIndex { get; set; }
+
+    /// <summary>
+    /// The name of the column header being inserted.
+    /// </summary>
+    public string ColumnName { get; set; } = "";
+
+    /// <summary>
+    /// The column letter (e.g., "A", "B", "Z", "AA").
+    /// </summary>
+    public string ColumnLetter { get; set; } = "";
+}

--- a/RaptorSheets.Core/Registries/SheetRegistry.cs
+++ b/RaptorSheets.Core/Registries/SheetRegistry.cs
@@ -1,0 +1,147 @@
+using Google.Apis.Sheets.v4.Data;
+using RaptorSheets.Core.Entities;
+using RaptorSheets.Core.Helpers;
+using RaptorSheets.Core.Models.Google;
+
+namespace RaptorSheets.Core.Registries;
+
+/// <summary>
+/// Generic orchestration shared by every domain's sheet-helper class (Gig, Stock, and future
+/// domains): "given a sheet name, look up its SheetModel/expected headers and its row-mapping
+/// delegate, then walk a batchGet response or Spreadsheet and apply them." Each domain package
+/// still owns its own strongly-typed entities and mapper delegates - this only removes the
+/// duplicated dictionary-plus-loop plumbing (and the near-identical MapData/GetMissingSheets
+/// implementations) that would otherwise be hand-rolled per domain.
+/// </summary>
+/// <typeparam name="TEntity">The domain's top-level SheetEntity type</typeparam>
+public class SheetRegistry<TEntity> where TEntity : class, ISheetEntity, new()
+{
+    private readonly Dictionary<string, Func<SheetModel>> _factories = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Action<TEntity, IList<IList<object>>>> _processors = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Registers a sheet by name with its SheetModel factory (used for header/layout definitions
+    /// and missing-sheet creation) and a processor that maps raw row values onto the entity. The
+    /// processor is fully domain-owned - it can call RaptorSheets.Core.Mappers.GenericSheetMapper&lt;T&gt;
+    /// (see <see cref="SheetRegistryExtensions.RegisterGeneric{TEntity, TRow}"/> for that common case)
+    /// or a domain's own hand-rolled mapper; the registry doesn't need to know which.
+    /// </summary>
+    public void Register(string sheetName, Func<SheetModel> sheetModelFactory, Action<TEntity, IList<IList<object>>> processor)
+    {
+        ArgumentNullException.ThrowIfNull(sheetModelFactory);
+        ArgumentNullException.ThrowIfNull(processor);
+
+        _factories[sheetName] = sheetModelFactory;
+        _processors[sheetName] = processor;
+    }
+
+    public bool IsRegistered(string sheetName) => _factories.ContainsKey(sheetName);
+
+    public IReadOnlyDictionary<string, Func<SheetModel>> Factories => _factories;
+
+    /// <summary>
+    /// Builds an entity from a batchGet response, dispatching each returned range to its
+    /// registered processor by sheet name (taken from the range's DataFilter). Returns null if
+    /// the response has no ranges to process (mirrors the historical per-domain behavior).
+    /// </summary>
+    public TEntity? MapData(BatchGetValuesByDataFilterResponse? response)
+    {
+        if (response?.ValueRanges == null)
+        {
+            return null;
+        }
+
+        var entity = new TEntity();
+
+        foreach (var matchedValue in response.ValueRanges)
+        {
+            var sheetName = matchedValue.DataFilters[0].A1Range;
+            var values = matchedValue.ValueRange.Values;
+            Process(entity, sheetName, values);
+        }
+
+        return entity;
+    }
+
+    /// <summary>
+    /// Builds an entity from a full Spreadsheet (grid-data) response.
+    /// </summary>
+    public TEntity MapData(Spreadsheet spreadsheet)
+    {
+        var entity = new TEntity();
+        entity.Properties.Name = spreadsheet.Properties.Title;
+
+        var sheetValues = SheetHelpers.GetSheetValues(spreadsheet);
+        foreach (var sheet in spreadsheet.Sheets)
+        {
+            if (sheetValues.TryGetValue(sheet.Properties.Title, out var values))
+            {
+                Process(entity, sheet.Properties.Title, values);
+            }
+        }
+
+        return entity;
+    }
+
+    private void Process(TEntity entity, string sheetName, IList<IList<object>> values)
+    {
+        if (values == null || values.Count == 0)
+        {
+            return;
+        }
+
+        if (_processors.TryGetValue(sheetName, out var processor))
+        {
+            processor(entity, values);
+        }
+    }
+
+    /// <summary>
+    /// Returns SheetModels for every registered sheet in <paramref name="canonicalSheetNames"/> that
+    /// isn't already present (by title, case-insensitive) in <paramref name="spreadsheet"/>.
+    /// </summary>
+    public List<SheetModel> GetMissingSheets(Spreadsheet spreadsheet, IEnumerable<string> canonicalSheetNames)
+    {
+        var existingTitles = spreadsheet.Sheets.Select(x => x.Properties.Title).ToList();
+        var missing = new List<SheetModel>();
+
+        foreach (var name in canonicalSheetNames)
+        {
+            if (existingTitles.Any(s => string.Equals(s, name, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            if (_factories.TryGetValue(name, out var factory))
+            {
+                missing.Add(factory());
+            }
+        }
+
+        return missing;
+    }
+}
+
+/// <summary>
+/// Convenience registration for the common case where a sheet's rows map through the generic,
+/// attribute-driven <see cref="RaptorSheets.Core.Mappers.GenericSheetMapper{T}"/> rather than a
+/// hand-rolled mapper. Still fully strongly-typed - TRow is a real entity class, not a generic cell/row.
+/// </summary>
+public static class SheetRegistryExtensions
+{
+    public static void RegisterGeneric<TEntity, TRow>(
+        this SheetRegistry<TEntity> registry,
+        string sheetName,
+        Func<SheetModel> sheetModelFactory,
+        Action<TEntity, List<TRow>> assign)
+        where TEntity : class, ISheetEntity, new()
+        where TRow : class, new()
+    {
+        registry.Register(sheetName, sheetModelFactory, (entity, values) =>
+        {
+            var headers = values[0];
+            entity.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, sheetModelFactory()));
+            assign(entity, Mappers.GenericSheetMapper<TRow>.MapFromRangeData(values));
+        });
+    }
+}

--- a/RaptorSheets.Core/Registries/SheetRegistry.cs
+++ b/RaptorSheets.Core/Registries/SheetRegistry.cs
@@ -1,5 +1,6 @@
 using Google.Apis.Sheets.v4.Data;
 using RaptorSheets.Core.Entities;
+using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Models.Google;
 
@@ -119,6 +120,121 @@ public class SheetRegistry<TEntity> where TEntity : class, ISheetEntity, new()
         }
 
         return missing;
+    }
+
+    /// <summary>
+    /// Checks a spreadsheet's tab names for sheets that don't correspond to any registered sheet.
+    /// Unlike <see cref="CheckSheetHeaders"/>, this only needs sheet tab metadata (no grid/cell
+    /// data), so it's safe to call with a cheap metadata-only spreadsheet fetch.
+    /// </summary>
+    public List<MessageEntity> CheckUnknownSheets(Spreadsheet spreadsheet)
+    {
+        var messages = new List<MessageEntity>();
+
+        if (spreadsheet == null)
+        {
+            messages.Add(MessageHelpers.CreateErrorMessage("Unable to retrieve sheet(s)", MessageTypeEnum.GENERAL));
+            return messages;
+        }
+
+        var sheets = spreadsheet.Sheets ?? [];
+        var unknownSheets = sheets.Where(s => !_factories.ContainsKey(s.Properties.Title));
+
+        messages.AddRange(UnknownSheetWarnings(unknownSheets));
+
+        return messages;
+    }
+
+    /// <summary>
+    /// Full header validation: for every known sheet present in <paramref name="spreadsheet"/>,
+    /// checks its actual header row (from grid data) against the registered SheetModel's expected
+    /// headers (missing/renamed/reordered columns); for every unrecognized tab, adds a warning.
+    /// Requires grid data (IncludeGridData=true) on <paramref name="spreadsheet"/>.
+    /// </summary>
+    public List<MessageEntity> CheckSheetHeaders(Spreadsheet spreadsheet)
+    {
+        var messages = new List<MessageEntity>();
+
+        if (spreadsheet == null)
+        {
+            messages.Add(MessageHelpers.CreateErrorMessage("Unable to retrieve sheet(s)", MessageTypeEnum.GENERAL));
+            return messages;
+        }
+
+        var sheets = spreadsheet.Sheets ?? [];
+        var knownSheets = sheets.Where(s => _factories.ContainsKey(s.Properties.Title)).ToList();
+        var unknownSheets = sheets.Except(knownSheets);
+
+        var headerMessages = KnownSheetHeaderMessages(knownSheets).ToList();
+        messages.AddRange(UnknownSheetWarnings(unknownSheets));
+
+        if (headerMessages.Count > 0)
+        {
+            messages.Add(MessageHelpers.CreateWarningMessage("Found sheet header issue(s)", MessageTypeEnum.CHECK_SHEET));
+            messages.AddRange(headerMessages);
+        }
+        else
+        {
+            messages.Add(MessageHelpers.CreateInfoMessage("No sheet header issues found", MessageTypeEnum.CHECK_SHEET));
+        }
+
+        return messages;
+    }
+
+    private IEnumerable<MessageEntity> KnownSheetHeaderMessages(IEnumerable<Sheet> knownSheets)
+    {
+        foreach (var sheet in knownSheets)
+        {
+            var sheetHeader = HeaderHelpers.GetHeadersFromCellData(sheet.Data?[0]?.RowData?[0]?.Values);
+
+            if (_factories.TryGetValue(sheet.Properties.Title, out var factory))
+            {
+                foreach (var msg in HeaderHelpers.CheckSheetHeaders(sheetHeader, factory()))
+                {
+                    yield return msg;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<MessageEntity> UnknownSheetWarnings(IEnumerable<Sheet> unknownSheets)
+    {
+        foreach (var sheet in unknownSheets)
+        {
+            yield return MessageHelpers.CreateWarningMessage($"Sheet {sheet.Properties.Title} does not match any known sheet name", MessageTypeEnum.CHECK_SHEET);
+        }
+    }
+
+    /// <summary>
+    /// Gets the SheetModel (headers/formulas/formats) for a registered sheet by name, or null if unknown.
+    /// </summary>
+    public SheetModel? GetSheetLayout(string sheetName)
+    {
+        if (string.IsNullOrEmpty(sheetName))
+        {
+            return null;
+        }
+
+        return _factories.TryGetValue(sheetName, out var factory) ? factory() : null;
+    }
+
+    /// <summary>
+    /// Gets SheetModels for every requested name that's registered, silently skipping unknown ones.
+    /// </summary>
+    public List<SheetModel> GetSheetLayouts(IEnumerable<string> sheetNames)
+    {
+        var models = new List<SheetModel>();
+
+        foreach (var name in sheetNames)
+        {
+            var model = GetSheetLayout(name);
+            if (model != null)
+            {
+                models.Add(model);
+            }
+        }
+
+        return models;
     }
 }
 

--- a/RaptorSheets.Core/Registries/SheetRegistry.cs
+++ b/RaptorSheets.Core/Registries/SheetRegistry.cs
@@ -66,6 +66,42 @@ public class SheetRegistry<TEntity> where TEntity : class, ISheetEntity, new()
     }
 
     /// <summary>
+    /// Detects columns missing entirely from a batchGet response, reusing the header row already
+    /// present in each range - no extra API call needed. SheetId is left at 0 on each result; the
+    /// caller fills it in from spreadsheet metadata it already has (e.g. the cheap, no-ranges
+    /// GetSheetInfo() call already used for unknown-sheet detection) before acting on it.
+    /// </summary>
+    public Dictionary<string, List<ColumnInsertionInfo>> DetectMissingColumns(BatchGetValuesByDataFilterResponse? response)
+    {
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>();
+
+        if (response?.ValueRanges == null)
+        {
+            return missingColumns;
+        }
+
+        foreach (var matchedValue in response.ValueRanges)
+        {
+            var sheetName = matchedValue.DataFilters[0].A1Range;
+            var values = matchedValue.ValueRange.Values;
+
+            if (values == null || values.Count == 0 || !_factories.TryGetValue(sheetName, out var factory))
+            {
+                continue;
+            }
+
+            HeaderHelpers.CheckSheetHeaders(values[0], factory(), out var insertionInfo);
+
+            if (insertionInfo.Count > 0)
+            {
+                missingColumns[sheetName] = insertionInfo;
+            }
+        }
+
+        return missingColumns;
+    }
+
+    /// <summary>
     /// Builds an entity from a full Spreadsheet (grid-data) response.
     /// </summary>
     public TEntity MapData(Spreadsheet spreadsheet)

--- a/RaptorSheets.Core/Registries/SheetRegistry.cs
+++ b/RaptorSheets.Core/Registries/SheetRegistry.cs
@@ -2,6 +2,7 @@ using Google.Apis.Sheets.v4.Data;
 using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Helpers;
+using RaptorSheets.Core.Models;
 using RaptorSheets.Core.Models.Google;
 
 namespace RaptorSheets.Core.Registries;
@@ -153,7 +154,20 @@ public class SheetRegistry<TEntity> where TEntity : class, ISheetEntity, new()
     /// </summary>
     public List<MessageEntity> CheckSheetHeaders(Spreadsheet spreadsheet)
     {
+        return CheckSheetHeaders(spreadsheet, out _);
+    }
+
+    /// <summary>
+    /// Same as <see cref="CheckSheetHeaders(Spreadsheet)"/>, but also reports which columns are
+    /// missing entirely and where they should be inserted (per sheet), so a caller can act on it
+    /// via <see cref="ColumnInsertionHelper.InsertMissingColumnsAsync{TEntity}"/>.
+    /// </summary>
+    /// <param name="spreadsheet">Spreadsheet with grid data (IncludeGridData=true)</param>
+    /// <param name="missingColumns">Sheet name -> missing columns for that sheet (empty if none found)</param>
+    public List<MessageEntity> CheckSheetHeaders(Spreadsheet spreadsheet, out Dictionary<string, List<ColumnInsertionInfo>> missingColumns)
+    {
         var messages = new List<MessageEntity>();
+        missingColumns = [];
 
         if (spreadsheet == null)
         {
@@ -165,7 +179,30 @@ public class SheetRegistry<TEntity> where TEntity : class, ISheetEntity, new()
         var knownSheets = sheets.Where(s => _factories.ContainsKey(s.Properties.Title)).ToList();
         var unknownSheets = sheets.Except(knownSheets);
 
-        var headerMessages = KnownSheetHeaderMessages(knownSheets).ToList();
+        var headerMessages = new List<MessageEntity>();
+
+        foreach (var sheet in knownSheets)
+        {
+            var sheetHeader = HeaderHelpers.GetHeadersFromCellData(sheet.Data?[0]?.RowData?[0]?.Values);
+
+            if (!_factories.TryGetValue(sheet.Properties.Title, out var factory))
+            {
+                continue;
+            }
+
+            headerMessages.AddRange(HeaderHelpers.CheckSheetHeaders(sheetHeader, factory(), out var insertionInfo));
+
+            if (insertionInfo.Count > 0)
+            {
+                foreach (var info in insertionInfo)
+                {
+                    info.SheetId = sheet.Properties.SheetId ?? 0;
+                }
+
+                missingColumns[sheet.Properties.Title] = insertionInfo;
+            }
+        }
+
         messages.AddRange(UnknownSheetWarnings(unknownSheets));
 
         if (headerMessages.Count > 0)
@@ -179,22 +216,6 @@ public class SheetRegistry<TEntity> where TEntity : class, ISheetEntity, new()
         }
 
         return messages;
-    }
-
-    private IEnumerable<MessageEntity> KnownSheetHeaderMessages(IEnumerable<Sheet> knownSheets)
-    {
-        foreach (var sheet in knownSheets)
-        {
-            var sheetHeader = HeaderHelpers.GetHeadersFromCellData(sheet.Data?[0]?.RowData?[0]?.Values);
-
-            if (_factories.TryGetValue(sheet.Properties.Title, out var factory))
-            {
-                foreach (var msg in HeaderHelpers.CheckSheetHeaders(sheetHeader, factory()))
-                {
-                    yield return msg;
-                }
-            }
-        }
     }
 
     private static IEnumerable<MessageEntity> UnknownSheetWarnings(IEnumerable<Sheet> unknownSheets)

--- a/RaptorSheets.Gig.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
+++ b/RaptorSheets.Gig.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Google.Apis.Sheets.v4.Data;
+using Moq;
+using RaptorSheets.Core.Models;
+using RaptorSheets.Core.Services;
+using RaptorSheets.Gig.Managers;
+using Xunit;
+
+namespace RaptorSheets.Gig.Tests.Unit.Managers;
+
+/// <summary>
+/// Covers the Gig-side wiring of the column auto-insertion feature: CheckSheetHeaders'
+/// out-param overload for detecting missing columns, and InsertMissingColumns for physically
+/// inserting them. The underlying logic (RaptorSheets.Core.Helpers.ColumnInsertionHelper,
+/// RaptorSheets.Core.Registries.SheetRegistry) has its own dedicated tests in RaptorSheets.Core.Tests -
+/// these just confirm Gig's manager delegates to it correctly.
+/// </summary>
+public class InsertMissingColumnsBehaviorTests
+{
+    [Fact]
+    public void CheckSheetHeaders_WithMissingColumn_DetectsInsertionInfo()
+    {
+        // Arrange - Trips sheet with only "Date" present; the real model has many more columns
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new()
+                {
+                    Properties = new SheetProperties { Title = "Trips", SheetId = 42 },
+                    Data =
+                    [
+                        new()
+                        {
+                            RowData = [new() { Values = [new() { FormattedValue = "Date" }] }]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // Act
+        var messages = GoogleSheetManager.CheckSheetHeaders(spreadsheet, out var missingColumns);
+
+        // Assert
+        Assert.NotEmpty(messages);
+        Assert.True(missingColumns.ContainsKey("Trips"));
+        Assert.NotEmpty(missingColumns["Trips"]);
+        Assert.All(missingColumns["Trips"], c => Assert.Equal(42, c.SheetId));
+    }
+
+    [Fact]
+    public async Task InsertMissingColumns_WithNoMissingColumns_DoesNotCallService()
+    {
+        // Arrange
+        var mockService = new Mock<IGoogleSheetService>();
+        var manager = new GoogleSheetManager(mockService.Object);
+
+        // Act
+        var result = await manager.InsertMissingColumns([]);
+
+        // Assert
+        Assert.Contains(result.Messages, m => m.Message.Contains("No missing columns to insert"));
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InsertMissingColumns_WithMissingColumn_CallsBatchUpdateAndReportsSuccess()
+    {
+        // Arrange
+        var mockService = new Mock<IGoogleSheetService>();
+        BatchUpdateSpreadsheetRequest? capturedRequest = null;
+        mockService
+            .Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>()))
+            .Callback<BatchUpdateSpreadsheetRequest>(r => capturedRequest = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new GoogleSheetManager(mockService.Object);
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Trips"] = [new ColumnInsertionInfo { SheetName = "Trips", SheetId = 7, ColumnIndex = 3, ColumnName = "Note" }]
+        };
+
+        // Act
+        var result = await manager.InsertMissingColumns(missingColumns);
+
+        // Assert
+        Assert.NotNull(capturedRequest);
+        Assert.Contains(capturedRequest.Requests, r => r.InsertDimension != null && r.InsertDimension.Range.SheetId == 7);
+        Assert.Contains(result.Messages, m => m.Message.Contains("Successfully inserted 1 missing column(s)"));
+    }
+}

--- a/RaptorSheets.Gig/Entities/SheetEntity.cs
+++ b/RaptorSheets.Gig/Entities/SheetEntity.cs
@@ -10,7 +10,7 @@ namespace RaptorSheets.Gig.Entities;
 /// Sheet order is determined by the declaration order in SheetsConfig.SheetNames.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class SheetEntity
+public class SheetEntity : ISheetEntity
 {
     [JsonPropertyName("properties")]
     public PropertyEntity Properties { get; set; } = new();

--- a/RaptorSheets.Gig/Helpers/GigSheetHelpers.cs
+++ b/RaptorSheets.Gig/Helpers/GigSheetHelpers.cs
@@ -103,6 +103,15 @@ public static class GigSheetHelpers
         return s_registry.CheckSheetHeaders(spreadsheet, out missingColumns);
     }
 
+    /// <summary>
+    /// Detects columns missing entirely from a batchGet response, reusing the header row already
+    /// present in each range - no extra API call. SheetId is left at 0; the caller fills it in.
+    /// </summary>
+    public static Dictionary<string, List<ColumnInsertionInfo>> DetectMissingColumns(BatchGetValuesByDataFilterResponse response)
+    {
+        return s_registry.DetectMissingColumns(response);
+    }
+
     public static SheetModel? GetSheetLayout(string sheetName)
     {
         return s_registry.GetSheetLayout(sheetName);

--- a/RaptorSheets.Gig/Helpers/GigSheetHelpers.cs
+++ b/RaptorSheets.Gig/Helpers/GigSheetHelpers.cs
@@ -1,8 +1,8 @@
 using Google.Apis.Sheets.v4.Data;
 using RaptorSheets.Core.Entities;
-using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Mappers;
 using RaptorSheets.Core.Models.Google;
+using RaptorSheets.Core.Registries;
 using RaptorSheets.Gig.Constants;
 using RaptorSheets.Gig.Entities;
 using RaptorSheets.Gig.Enums;
@@ -12,12 +12,17 @@ namespace RaptorSheets.Gig.Helpers;
 
 /// <summary>
 /// Helper methods for Google Sheets operations in the Gig domain.
-/// 
+///
 /// HYBRID APPROACH:
 /// Uses both constants and enums for optimal performance and maintainability:
 /// - Switch statements use normalized strings for performance
 /// - Enums provide type safety for API operations
 /// - Constants ensure consistent string values throughout
+///
+/// Per-sheet dispatch (headers, row mapping, missing-sheet detection) is delegated to a shared
+/// RaptorSheets.Core.Registries.SheetRegistry&lt;SheetEntity&gt; instead of hand-rolled dictionaries/loops,
+/// so the same orchestration is reused by other domain packages (see RaptorSheets.Stock) without
+/// requiring a generic Cell/Row entity model.
 /// </summary>
 public static class GigSheetHelpers
 {
@@ -37,157 +42,36 @@ public static class GigSheetHelpers
         return SheetsConfig.SheetUtilities.GetAllSheetNames();
     }
 
-    // Sheet name -> SheetModel factory (case-insensitive)
-    private static readonly Dictionary<string, Func<SheetModel>> s_sheetFactories = new(StringComparer.OrdinalIgnoreCase)
-    {
-        { SheetsConfig.SheetNames.Addresses, AddressMapper.GetSheet },
-        { SheetsConfig.SheetNames.Daily, DailyMapper.GetSheet },
-        { SheetsConfig.SheetNames.Expenses, () => GenericSheetMapper<ExpenseEntity>.GetSheet(SheetsConfig.ExpenseSheet) },
-        { SheetsConfig.SheetNames.Monthly, MonthlyMapper.GetSheet },
-        { SheetsConfig.SheetNames.Names, NameMapper.GetSheet },
-        { SheetsConfig.SheetNames.Places, PlaceMapper.GetSheet },
-        { SheetsConfig.SheetNames.Deliveries, DeliveryMapper.GetSheet },
-        { SheetsConfig.SheetNames.Locations, LocationMapper.GetSheet },
-        { SheetsConfig.SheetNames.Regions, RegionMapper.GetSheet },
-        { SheetsConfig.SheetNames.Setup, () => GenericSheetMapper<SetupEntity>.GetSheet(SheetsConfig.SetupSheet) },
-        { SheetsConfig.SheetNames.Services, ServiceMapper.GetSheet },
-        { SheetsConfig.SheetNames.Shifts, ShiftMapper.GetSheet },
-        { SheetsConfig.SheetNames.Trips, TripMapper.GetSheet },
-        { SheetsConfig.SheetNames.Types, TypeMapper.GetSheet },
-        { SheetsConfig.SheetNames.Weekdays, WeekdayMapper.GetSheet },
-        { SheetsConfig.SheetNames.Weekly, WeeklyMapper.GetSheet },
-        { SheetsConfig.SheetNames.Yearly, YearlyMapper.GetSheet }
-    };
+    private static readonly SheetRegistry<SheetEntity> s_registry = BuildRegistry();
 
-    // Sheet name -> processor action (case-insensitive)
-    private static readonly Dictionary<string, Action<SheetEntity, IList<IList<object>>>> s_sheetProcessors = new(StringComparer.OrdinalIgnoreCase)
+    private static SheetRegistry<SheetEntity> BuildRegistry()
     {
-        { SheetsConfig.SheetNames.Addresses, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, AddressMapper.GetSheet()));
-                se.Addresses = GenericSheetMapper<AddressEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Daily, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, DailyMapper.GetSheet()));
-                se.Daily = GenericSheetMapper<DailyEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Expenses, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, GenericSheetMapper<ExpenseEntity>.GetSheet(SheetsConfig.ExpenseSheet)));
-                se.Expenses = GenericSheetMapper<ExpenseEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Monthly, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, MonthlyMapper.GetSheet()));
-                se.Monthly = GenericSheetMapper<MonthlyEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Names, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, NameMapper.GetSheet()));
-                se.Names = GenericSheetMapper<NameEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Places, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, PlaceMapper.GetSheet()));
-                se.Places = GenericSheetMapper<PlaceEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Deliveries, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, DeliveryMapper.GetSheet()));
-                se.Deliveries = GenericSheetMapper<DeliveryEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Locations, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, LocationMapper.GetSheet()));
-                se.Locations = GenericSheetMapper<LocationEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Regions, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, RegionMapper.GetSheet()));
-                se.Regions = GenericSheetMapper<RegionEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Services, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, ServiceMapper.GetSheet()));
-                se.Services = GenericSheetMapper<ServiceEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Setup, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, GenericSheetMapper<SetupEntity>.GetSheet(SheetsConfig.SetupSheet)));
-                se.Setup = GenericSheetMapper<SetupEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Shifts, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, ShiftMapper.GetSheet()));
-                se.Shifts = GenericSheetMapper<ShiftEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Trips, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, TripMapper.GetSheet()));
-                se.Trips = GenericSheetMapper<TripEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Types, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, TypeMapper.GetSheet()));
-                se.Types = GenericSheetMapper<TypeEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Weekdays, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, WeekdayMapper.GetSheet()));
-                se.Weekdays = GenericSheetMapper<WeekdayEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Weekly, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, WeeklyMapper.GetSheet()));
-                se.Weekly = GenericSheetMapper<WeeklyEntity>.MapFromRangeData(values);
-            }
-        },
-        { SheetsConfig.SheetNames.Yearly, (se, values) => {
-                var headers = values[0];
-                se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, YearlyMapper.GetSheet()));
-                se.Yearly = GenericSheetMapper<YearlyEntity>.MapFromRangeData(values);
-            }
-        }
-    };
+        var registry = new SheetRegistry<SheetEntity>();
+
+        registry.RegisterGeneric<SheetEntity, AddressEntity>(SheetsConfig.SheetNames.Addresses, AddressMapper.GetSheet, (se, rows) => se.Addresses = rows);
+        registry.RegisterGeneric<SheetEntity, DailyEntity>(SheetsConfig.SheetNames.Daily, DailyMapper.GetSheet, (se, rows) => se.Daily = rows);
+        registry.RegisterGeneric<SheetEntity, ExpenseEntity>(SheetsConfig.SheetNames.Expenses, () => GenericSheetMapper<ExpenseEntity>.GetSheet(SheetsConfig.ExpenseSheet), (se, rows) => se.Expenses = rows);
+        registry.RegisterGeneric<SheetEntity, MonthlyEntity>(SheetsConfig.SheetNames.Monthly, MonthlyMapper.GetSheet, (se, rows) => se.Monthly = rows);
+        registry.RegisterGeneric<SheetEntity, NameEntity>(SheetsConfig.SheetNames.Names, NameMapper.GetSheet, (se, rows) => se.Names = rows);
+        registry.RegisterGeneric<SheetEntity, PlaceEntity>(SheetsConfig.SheetNames.Places, PlaceMapper.GetSheet, (se, rows) => se.Places = rows);
+        registry.RegisterGeneric<SheetEntity, DeliveryEntity>(SheetsConfig.SheetNames.Deliveries, DeliveryMapper.GetSheet, (se, rows) => se.Deliveries = rows);
+        registry.RegisterGeneric<SheetEntity, LocationEntity>(SheetsConfig.SheetNames.Locations, LocationMapper.GetSheet, (se, rows) => se.Locations = rows);
+        registry.RegisterGeneric<SheetEntity, RegionEntity>(SheetsConfig.SheetNames.Regions, RegionMapper.GetSheet, (se, rows) => se.Regions = rows);
+        registry.RegisterGeneric<SheetEntity, SetupEntity>(SheetsConfig.SheetNames.Setup, () => GenericSheetMapper<SetupEntity>.GetSheet(SheetsConfig.SetupSheet), (se, rows) => se.Setup = rows);
+        registry.RegisterGeneric<SheetEntity, ServiceEntity>(SheetsConfig.SheetNames.Services, ServiceMapper.GetSheet, (se, rows) => se.Services = rows);
+        registry.RegisterGeneric<SheetEntity, ShiftEntity>(SheetsConfig.SheetNames.Shifts, ShiftMapper.GetSheet, (se, rows) => se.Shifts = rows);
+        registry.RegisterGeneric<SheetEntity, TripEntity>(SheetsConfig.SheetNames.Trips, TripMapper.GetSheet, (se, rows) => se.Trips = rows);
+        registry.RegisterGeneric<SheetEntity, TypeEntity>(SheetsConfig.SheetNames.Types, TypeMapper.GetSheet, (se, rows) => se.Types = rows);
+        registry.RegisterGeneric<SheetEntity, WeekdayEntity>(SheetsConfig.SheetNames.Weekdays, WeekdayMapper.GetSheet, (se, rows) => se.Weekdays = rows);
+        registry.RegisterGeneric<SheetEntity, WeeklyEntity>(SheetsConfig.SheetNames.Weekly, WeeklyMapper.GetSheet, (se, rows) => se.Weekly = rows);
+        registry.RegisterGeneric<SheetEntity, YearlyEntity>(SheetsConfig.SheetNames.Yearly, YearlyMapper.GetSheet, (se, rows) => se.Yearly = rows);
+
+        return registry;
+    }
 
     public static List<SheetModel> GetMissingSheets(Spreadsheet spreadsheet)
     {
-        var spreadsheetSheets = spreadsheet.Sheets.Select(x => x.Properties.Title).ToList();
-        var sheetData = new List<SheetModel>();
-
-        var sheetNames = GetSheetNames();
-
-        // Loop through all sheets to see if they exist.
-        foreach (var name in sheetNames)
-        {
-            if (spreadsheetSheets.Any(s => string.Equals(s, name, StringComparison.OrdinalIgnoreCase)))
-            {
-                continue;
-            }
-
-            if (s_sheetFactories.TryGetValue(name, out var factory))
-            {
-                sheetData.Add(factory());
-            }
-        }
-
-        return sheetData;
+        return s_registry.GetMissingSheets(spreadsheet, GetSheetNames());
     }
 
     public static DataValidationRule GetDataValidation(ValidationEnum validation, string? range = "")
@@ -237,53 +121,11 @@ public static class GigSheetHelpers
 
     public static SheetEntity? MapData(Spreadsheet spreadsheet)
     {
-        var sheetEntity = new SheetEntity
-        {
-            Properties = new PropertyEntity
-            {
-                Name = spreadsheet.Properties.Title,
-            }
-        };
-
-        var sheetValues = SheetHelpers.GetSheetValues(spreadsheet);
-        foreach (var sheet in spreadsheet.Sheets)
-        {
-            var values = sheetValues[sheet.Properties.Title];
-            ProcessSheetData(sheetEntity, sheet.Properties.Title, values);
-        }
-
-        return sheetEntity;
+        return s_registry.MapData(spreadsheet);
     }
 
     public static SheetEntity? MapData(BatchGetValuesByDataFilterResponse response)
     {
-        if (response.ValueRanges == null)
-        {
-            return null;
-        }
-
-        var sheetEntity = new SheetEntity();
-
-        foreach (var matchedValue in response.ValueRanges)
-        {
-            var sheetRange = matchedValue.DataFilters[0].A1Range;
-            var values = matchedValue.ValueRange.Values;
-            ProcessSheetData(sheetEntity, sheetRange, values);
-        }
-
-        return sheetEntity;
-    }
-
-    private static void ProcessSheetData(SheetEntity sheetEntity, string sheetName, IList<IList<object>> values)
-    {
-        if (values == null || values.Count == 0)
-        {
-            return;
-        }
-
-        if (s_sheetProcessors.TryGetValue(sheetName, out var processor))
-        {
-            processor(sheetEntity, values);
-        }
+        return s_registry.MapData(response);
     }
 }

--- a/RaptorSheets.Gig/Helpers/GigSheetHelpers.cs
+++ b/RaptorSheets.Gig/Helpers/GigSheetHelpers.cs
@@ -1,6 +1,7 @@
 using Google.Apis.Sheets.v4.Data;
 using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Mappers;
+using RaptorSheets.Core.Models;
 using RaptorSheets.Core.Models.Google;
 using RaptorSheets.Core.Registries;
 using RaptorSheets.Gig.Constants;
@@ -90,6 +91,16 @@ public static class GigSheetHelpers
     public static List<MessageEntity> CheckSheetHeaders(Spreadsheet spreadsheet)
     {
         return s_registry.CheckSheetHeaders(spreadsheet);
+    }
+
+    /// <summary>
+    /// Same as <see cref="CheckSheetHeaders(Spreadsheet)"/>, but also reports which columns are
+    /// missing entirely and where they should be inserted, for use with
+    /// <see cref="RaptorSheets.Core.Helpers.ColumnInsertionHelper"/>.
+    /// </summary>
+    public static List<MessageEntity> CheckSheetHeaders(Spreadsheet spreadsheet, out Dictionary<string, List<ColumnInsertionInfo>> missingColumns)
+    {
+        return s_registry.CheckSheetHeaders(spreadsheet, out missingColumns);
     }
 
     public static SheetModel? GetSheetLayout(string sheetName)

--- a/RaptorSheets.Gig/Helpers/GigSheetHelpers.cs
+++ b/RaptorSheets.Gig/Helpers/GigSheetHelpers.cs
@@ -74,6 +74,34 @@ public static class GigSheetHelpers
         return s_registry.GetMissingSheets(spreadsheet, GetSheetNames());
     }
 
+    /// <summary>
+    /// Checks a spreadsheet's tab names for sheets that don't correspond to any known Gig sheet.
+    /// Only needs sheet tab metadata (no grid/cell data) - safe to call with a cheap, no-ranges
+    /// spreadsheet fetch. Known-sheet header validation happens separately via <see cref="MapData(BatchGetValuesByDataFilterResponse)"/>.
+    /// </summary>
+    public static List<MessageEntity> CheckUnknownSheets(Spreadsheet spreadsheet)
+    {
+        return s_registry.CheckUnknownSheets(spreadsheet);
+    }
+
+    /// <summary>
+    /// Full header validation against grid-data (IncludeGridData=true) spreadsheet metadata.
+    /// </summary>
+    public static List<MessageEntity> CheckSheetHeaders(Spreadsheet spreadsheet)
+    {
+        return s_registry.CheckSheetHeaders(spreadsheet);
+    }
+
+    public static SheetModel? GetSheetLayout(string sheetName)
+    {
+        return s_registry.GetSheetLayout(sheetName);
+    }
+
+    public static List<SheetModel> GetSheetLayouts(IEnumerable<string> sheetNames)
+    {
+        return s_registry.GetSheetLayouts(sheetNames);
+    }
+
     public static DataValidationRule GetDataValidation(ValidationEnum validation, string? range = "")
     {
         var dataValidation = new DataValidationRule();

--- a/RaptorSheets.Gig/Managers/GoogleSheetManager.Crud.cs
+++ b/RaptorSheets.Gig/Managers/GoogleSheetManager.Crud.cs
@@ -309,6 +309,34 @@ public partial class GoogleSheetManager
             }
 
             data = GigSheetHelpers.MapData(response) ?? new SheetEntity();
+
+            // Auto-heal: if any expected INPUT columns are missing entirely, insert them at their
+            // correct position (matching the canonical header order, not appended at the end) and
+            // write their header text. HideHeaderName columns (populated by a spilling QUERY
+            // formula, e.g. Delivery/Location's Pay/Tips/.../First Trip/Last Trip) are never
+            // candidates here - HeaderHelpers.CheckSheetHeaders already excludes them, since
+            // inserting one would land inside the query's contiguous spill range and break it.
+            // Detection reuses the header row already in `response` (no extra API call); SheetId
+            // comes from the same cheap metadata fetch used above for CheckUnknownSheets. Only the
+            // actual insert costs a real API call, and only when something is genuinely missing.
+            var missingColumns = GigSheetHelpers.DetectMissingColumns(response);
+            if (missingColumns.Count > 0 && spreadsheetInfo?.Sheets != null)
+            {
+                foreach (var (sheetName, columns) in missingColumns)
+                {
+                    var sheetId = spreadsheetInfo.Sheets
+                        .FirstOrDefault(s => string.Equals(s.Properties.Title, sheetName, StringComparison.OrdinalIgnoreCase))
+                        ?.Properties.SheetId ?? 0;
+
+                    foreach (var column in columns)
+                    {
+                        column.SheetId = sheetId;
+                    }
+                }
+
+                var insertResult = await InsertMissingColumns(missingColumns);
+                messages.AddRange(insertResult.Messages);
+            }
         }
 
         if (spreadsheetInfo != null)

--- a/RaptorSheets.Gig/Managers/GoogleSheetManager.Crud.cs
+++ b/RaptorSheets.Gig/Managers/GoogleSheetManager.Crud.cs
@@ -309,6 +309,31 @@ public partial class GoogleSheetManager
             }
 
             data = GigSheetHelpers.MapData(response) ?? new SheetEntity();
+
+            // Auto-heal: if any expected columns are missing entirely, insert them at their
+            // correct position (matching the canonical header order, not appended at the end)
+            // and write their header text. Detection reuses the header row already in `response`
+            // (no extra API call); SheetId comes from the same cheap metadata fetch used above
+            // for CheckUnknownSheets. Only the actual insert costs a real API call, and only when
+            // something is genuinely missing.
+            var missingColumns = GigSheetHelpers.DetectMissingColumns(response);
+            if (missingColumns.Count > 0 && spreadsheetInfo?.Sheets != null)
+            {
+                foreach (var (sheetName, columns) in missingColumns)
+                {
+                    var sheetId = spreadsheetInfo.Sheets
+                        .FirstOrDefault(s => string.Equals(s.Properties.Title, sheetName, StringComparison.OrdinalIgnoreCase))
+                        ?.Properties.SheetId ?? 0;
+
+                    foreach (var column in columns)
+                    {
+                        column.SheetId = sheetId;
+                    }
+                }
+
+                var insertResult = await InsertMissingColumns(missingColumns);
+                messages.AddRange(insertResult.Messages);
+            }
         }
 
         if (spreadsheetInfo != null)

--- a/RaptorSheets.Gig/Managers/GoogleSheetManager.Crud.cs
+++ b/RaptorSheets.Gig/Managers/GoogleSheetManager.Crud.cs
@@ -309,31 +309,6 @@ public partial class GoogleSheetManager
             }
 
             data = GigSheetHelpers.MapData(response) ?? new SheetEntity();
-
-            // Auto-heal: if any expected columns are missing entirely, insert them at their
-            // correct position (matching the canonical header order, not appended at the end)
-            // and write their header text. Detection reuses the header row already in `response`
-            // (no extra API call); SheetId comes from the same cheap metadata fetch used above
-            // for CheckUnknownSheets. Only the actual insert costs a real API call, and only when
-            // something is genuinely missing.
-            var missingColumns = GigSheetHelpers.DetectMissingColumns(response);
-            if (missingColumns.Count > 0 && spreadsheetInfo?.Sheets != null)
-            {
-                foreach (var (sheetName, columns) in missingColumns)
-                {
-                    var sheetId = spreadsheetInfo.Sheets
-                        .FirstOrDefault(s => string.Equals(s.Properties.Title, sheetName, StringComparison.OrdinalIgnoreCase))
-                        ?.Properties.SheetId ?? 0;
-
-                    foreach (var column in columns)
-                    {
-                        column.SheetId = sheetId;
-                    }
-                }
-
-                var insertResult = await InsertMissingColumns(missingColumns);
-                messages.AddRange(insertResult.Messages);
-            }
         }
 
         if (spreadsheetInfo != null)

--- a/RaptorSheets.Gig/Managers/GoogleSheetManager.Metadata.cs
+++ b/RaptorSheets.Gig/Managers/GoogleSheetManager.Metadata.cs
@@ -2,13 +2,9 @@ using Google.Apis.Sheets.v4.Data;
 using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Extensions;
-using RaptorSheets.Core.Helpers;
-using RaptorSheets.Core.Mappers;
 using RaptorSheets.Core.Models.Google;
 using RaptorSheets.Gig.Constants;
-using RaptorSheets.Gig.Entities;
 using RaptorSheets.Gig.Helpers;
-using RaptorSheets.Gig.Mappers;
 
 namespace RaptorSheets.Gig.Managers;
 
@@ -23,31 +19,6 @@ public partial class GoogleSheetManager
     public async Task<List<PropertyEntity>> GetAllSheetProperties()
     {
         return await GetSheetProperties(SheetsConfig.SheetUtilities.GetAllSheetNames());
-    }
-
-    private static IEnumerable<MessageEntity> GetHeaderMessagesForKnownSheets(IEnumerable<Sheet> knownSheets)
-    {
-        foreach (var sheet in knownSheets)
-        {
-            var sheetName = sheet.Properties.Title;
-            var sheetHeader = HeaderHelpers.GetHeadersFromCellData(sheet.Data?[0]?.RowData?[0]?.Values);
-
-            if (s_headerFactories.TryGetValue(sheetName, out var factory))
-            {
-                foreach (var msg in HeaderHelpers.CheckSheetHeaders(sheetHeader, factory()))
-                {
-                    yield return msg;
-                }
-            }
-        }
-    }
-
-    private static IEnumerable<MessageEntity> GetUnknownSheetWarnings(IEnumerable<Sheet> unknownSheets)
-    {
-        foreach (var sheet in unknownSheets)
-        {
-            yield return MessageHelpers.CreateWarningMessage($"Sheet {sheet.Properties.Title} does not match any known sheet name", MessageTypeEnum.CHECK_SHEET);
-        }
     }
 
     public async Task<List<PropertyEntity>> GetSheetProperties(List<string> sheets)
@@ -138,82 +109,20 @@ public partial class GoogleSheetManager
 
     #region Header Validation
 
-    // Sheet name -> SheetModel factory (case-insensitive) used for header checks
-    private static readonly Dictionary<string, Func<SheetModel>> s_headerFactories = new(StringComparer.OrdinalIgnoreCase)
-    {
-        { SheetsConfig.SheetNames.Addresses, AddressMapper.GetSheet },
-        { SheetsConfig.SheetNames.Daily, DailyMapper.GetSheet },
-        { SheetsConfig.SheetNames.Expenses, () => GenericSheetMapper<ExpenseEntity>.GetSheet(SheetsConfig.ExpenseSheet) },
-        { SheetsConfig.SheetNames.Monthly, MonthlyMapper.GetSheet },
-        { SheetsConfig.SheetNames.Names, NameMapper.GetSheet },
-        { SheetsConfig.SheetNames.Places, PlaceMapper.GetSheet },
-        { SheetsConfig.SheetNames.Deliveries, DeliveryMapper.GetSheet },
-        { SheetsConfig.SheetNames.Locations, LocationMapper.GetSheet },
-        { SheetsConfig.SheetNames.Regions, RegionMapper.GetSheet },
-        { SheetsConfig.SheetNames.Services, ServiceMapper.GetSheet },
-        { SheetsConfig.SheetNames.Setup, () => GenericSheetMapper<SetupEntity>.GetSheet(SheetsConfig.SetupSheet) },
-        { SheetsConfig.SheetNames.Shifts, ShiftMapper.GetSheet },
-        { SheetsConfig.SheetNames.Trips, TripMapper.GetSheet },
-        { SheetsConfig.SheetNames.Types, TypeMapper.GetSheet },
-        { SheetsConfig.SheetNames.Weekdays, WeekdayMapper.GetSheet },
-        { SheetsConfig.SheetNames.Weekly, WeeklyMapper.GetSheet },
-        { SheetsConfig.SheetNames.Yearly, YearlyMapper.GetSheet }
-    };
-
     /// <summary>
-    /// Checks a spreadsheet's tab names for sheets that don't correspond to any known RaptorSheets
-    /// sheet. Unlike <see cref="CheckSheetHeaders"/>, this only needs sheet tab metadata (no grid/cell
-    /// data), so it's safe to call with a cheap <c>GetSheetInfo()</c> (no ranges) result. Known-sheet
-    /// header validation (missing/renamed/reordered columns) is handled separately, per-sheet, by
-    /// <see cref="HeaderHelpers.CheckSheetHeaders(IList{object}, Models.Google.SheetModel)"/> using data
-    /// already fetched via batchGet - it does not need to be repeated here.
+    /// Checks a spreadsheet's tab names for sheets that don't correspond to any known Gig sheet.
+    /// Only needs sheet tab metadata (no grid/cell data), so it's safe to call with a cheap
+    /// <c>GetSheetInfo()</c> (no ranges) result. Known-sheet header validation (missing/renamed/
+    /// reordered columns) is handled separately, per-sheet, using data already fetched via batchGet.
     /// </summary>
     public static List<MessageEntity> CheckUnknownSheets(Spreadsheet sheetInfoResponse)
     {
-        var messages = new List<MessageEntity>();
-
-        if (sheetInfoResponse == null)
-        {
-            messages.Add(MessageHelpers.CreateErrorMessage($"Unable to retrieve sheet(s)", MessageTypeEnum.GENERAL));
-            return messages;
-        }
-
-        var sheets = sheetInfoResponse.Sheets ?? new List<Sheet>();
-        var unknownSheets = sheets.Where(s => !s_headerFactories.ContainsKey(s.Properties.Title));
-
-        messages.AddRange(GetUnknownSheetWarnings(unknownSheets));
-
-        return messages;
+        return GigSheetHelpers.CheckUnknownSheets(sheetInfoResponse);
     }
 
     public static List<MessageEntity> CheckSheetHeaders(Spreadsheet sheetInfoResponse)
     {
-        var messages = new List<MessageEntity>();
-
-        if (sheetInfoResponse == null)
-        {
-            messages.Add(MessageHelpers.CreateErrorMessage($"Unable to retrieve sheet(s)", MessageTypeEnum.GENERAL));
-            return messages;
-        }
-        // Separate known and unknown sheets to simplify logic
-        var sheets = sheetInfoResponse.Sheets ?? new List<Sheet>();
-        var knownSheets = sheets.Where(s => s_headerFactories.ContainsKey(s.Properties.Title));
-        var unknownSheets = sheets.Except(knownSheets);
-
-        var headerMessages = GetHeaderMessagesForKnownSheets(knownSheets).ToList();
-        messages.AddRange(GetUnknownSheetWarnings(unknownSheets));
-
-        if (headerMessages.Count > 0)
-        {
-            messages.Add(MessageHelpers.CreateWarningMessage($"Found sheet header issue(s)", MessageTypeEnum.CHECK_SHEET));
-            messages.AddRange(headerMessages);
-        }
-        else
-        {
-            messages.Add(MessageHelpers.CreateInfoMessage($"No sheet header issues found", MessageTypeEnum.CHECK_SHEET));
-        }
-
-        return messages;
+        return GigSheetHelpers.CheckSheetHeaders(sheetInfoResponse);
     }
 
     #endregion
@@ -231,14 +140,7 @@ public partial class GoogleSheetManager
     {
         try
         {
-            // Use the centralized factory map for sheet layouts (case-insensitive)
-            if (string.IsNullOrEmpty(sheet))
-                return null;
-
-            if (s_headerFactories.TryGetValue(sheet, out var factory))
-                return factory();
-
-            return null;
+            return GigSheetHelpers.GetSheetLayout(sheet);
         }
         catch (Exception)
         {

--- a/RaptorSheets.Gig/Managers/GoogleSheetManager.Metadata.cs
+++ b/RaptorSheets.Gig/Managers/GoogleSheetManager.Metadata.cs
@@ -2,8 +2,11 @@ using Google.Apis.Sheets.v4.Data;
 using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Extensions;
+using RaptorSheets.Core.Helpers;
+using RaptorSheets.Core.Models;
 using RaptorSheets.Core.Models.Google;
 using RaptorSheets.Gig.Constants;
+using RaptorSheets.Gig.Entities;
 using RaptorSheets.Gig.Helpers;
 
 namespace RaptorSheets.Gig.Managers;
@@ -123,6 +126,24 @@ public partial class GoogleSheetManager
     public static List<MessageEntity> CheckSheetHeaders(Spreadsheet sheetInfoResponse)
     {
         return GigSheetHelpers.CheckSheetHeaders(sheetInfoResponse);
+    }
+
+    /// <summary>
+    /// Same as <see cref="CheckSheetHeaders(Spreadsheet)"/>, but also reports which columns are
+    /// missing entirely and where they should be inserted, for use with <see cref="InsertMissingColumns"/>.
+    /// </summary>
+    public static List<MessageEntity> CheckSheetHeaders(Spreadsheet sheetInfoResponse, out Dictionary<string, List<ColumnInsertionInfo>> missingColumns)
+    {
+        return GigSheetHelpers.CheckSheetHeaders(sheetInfoResponse, out missingColumns);
+    }
+
+    /// <summary>
+    /// Physically inserts columns detected as missing by <see cref="CheckSheetHeaders(Spreadsheet, out Dictionary{string, List{ColumnInsertionInfo}})"/>
+    /// at their expected position, and writes the header text into each newly-inserted column.
+    /// </summary>
+    public async Task<SheetEntity> InsertMissingColumns(Dictionary<string, List<ColumnInsertionInfo>> missingColumns)
+    {
+        return await ColumnInsertionHelper.InsertMissingColumnsAsync<SheetEntity>(_googleSheetService, missingColumns);
     }
 
     #endregion

--- a/RaptorSheets.Gig/Managers/GoogleSheetManager.cs
+++ b/RaptorSheets.Gig/Managers/GoogleSheetManager.cs
@@ -2,6 +2,7 @@ using Google.Apis.Sheets.v4.Data;
 using Microsoft.Extensions.Logging;
 using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Managers;
+using RaptorSheets.Core.Models;
 using RaptorSheets.Core.Models.Google;
 using RaptorSheets.Gig.Entities;
 
@@ -32,7 +33,10 @@ public interface IGoogleSheetManager
     Task<BatchGetValuesByDataFilterResponse?> GetBatchData(List<string> sheets);
     SheetModel? GetSheetLayout(string sheet);
     List<SheetModel> GetSheetLayouts(List<string> sheets);
-    
+
+    // Header Management
+    Task<SheetEntity> InsertMissingColumns(Dictionary<string, List<ColumnInsertionInfo>> missingColumns);
+
     // Demo Data Generation
     SheetEntity GenerateDemoData(DateTime? startDate = null, DateTime? endDate = null, int? seed = null);
 }

--- a/RaptorSheets.Gig/Managers/GoogleSheetManager.cs
+++ b/RaptorSheets.Gig/Managers/GoogleSheetManager.cs
@@ -1,9 +1,8 @@
 using Google.Apis.Sheets.v4.Data;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using RaptorSheets.Core.Entities;
+using RaptorSheets.Core.Managers;
 using RaptorSheets.Core.Models.Google;
-using RaptorSheets.Core.Services;
 using RaptorSheets.Gig.Entities;
 
 namespace RaptorSheets.Gig.Managers;
@@ -48,24 +47,20 @@ public interface IGoogleSheetManager
 /// - GoogleSheetManager.Demo.cs (Demo data generation)
 /// - GoogleSheetManager.Helpers.cs (Private helpers)
 /// </summary>
-public partial class GoogleSheetManager : IGoogleSheetManager
+public partial class GoogleSheetManager : GoogleSheetManagerBase, IGoogleSheetManager
 {
-    private readonly RaptorSheets.Core.Services.IGoogleSheetService _googleSheetService;
-    private readonly ILogger _logger;
-
     public GoogleSheetManager(RaptorSheets.Core.Services.IGoogleSheetService googleSheetService, ILogger? logger = null)
+        : base(googleSheetService, logger)
     {
-        _googleSheetService = googleSheetService ?? throw new ArgumentNullException(nameof(googleSheetService));
-        _logger = logger ?? NullLogger.Instance;
     }
 
     public GoogleSheetManager(string accessToken, string spreadsheetId, ILogger? logger = null)
-        : this(new RaptorSheets.Core.Services.GoogleSheetService(accessToken, spreadsheetId, logger), logger)
+        : base(accessToken, spreadsheetId, logger)
     {
     }
 
     public GoogleSheetManager(Dictionary<string, string> parameters, string spreadsheetId, ILogger? logger = null)
-        : this(new RaptorSheets.Core.Services.GoogleSheetService(parameters, spreadsheetId, logger), logger)
+        : base(parameters, spreadsheetId, logger)
     {
     }
 }

--- a/RaptorSheets.Stock.Tests/Unit/Managers/GoogleSheetManagerTests.cs
+++ b/RaptorSheets.Stock.Tests/Unit/Managers/GoogleSheetManagerTests.cs
@@ -82,6 +82,72 @@ public class GoogleSheetManagerTests
     }
 
     [Fact]
+    public void CheckSheetHeaders_WithMismatchedAccountsHeader_ShouldReportIssue()
+    {
+        // Accounts (and Tickers) header validation used to be silently skipped (dead/commented-out
+        // switch cases) - this confirms the shared registry-backed implementation actually checks them.
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new()
+                {
+                    Properties = new SheetProperties { Title = "Accounts" },
+                    Data =
+                    [
+                        new()
+                        {
+                            RowData =
+                            [
+                                new() { Values = [new() { FormattedValue = "NotARealHeader" }] }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var result = GoogleSheetManager.CheckSheetHeaders(spreadsheet);
+
+        Assert.Contains(result, m => m.Message.Contains("Found sheet header issue(s)"));
+    }
+
+    [Fact]
+    public void CheckUnknownSheets_WithUnknownTab_ShouldReturnWarning()
+    {
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new() { Properties = new SheetProperties { Title = "Stocks" } },
+                new() { Properties = new SheetProperties { Title = "SomeRandomTab" } }
+            ]
+        };
+
+        var result = GoogleSheetManager.CheckUnknownSheets(spreadsheet);
+
+        Assert.Contains(result, m => m.Message.Contains("SomeRandomTab") && m.Message.Contains("does not match any known sheet name"));
+    }
+
+    [Fact]
+    public void CheckUnknownSheets_WithOnlyKnownSheets_ShouldReturnNoWarnings()
+    {
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new() { Properties = new SheetProperties { Title = "Accounts" } },
+                new() { Properties = new SheetProperties { Title = "Stocks" } },
+                new() { Properties = new SheetProperties { Title = "Tickers" } }
+            ]
+        };
+
+        var result = GoogleSheetManager.CheckUnknownSheets(spreadsheet);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
     public void GetSheetLayout_WithValidSheet_ReturnsModel()
     {
         var manager = new GoogleSheetManager("token", "spreadsheet");

--- a/RaptorSheets.Stock.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
+++ b/RaptorSheets.Stock.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
@@ -1,0 +1,84 @@
+using Google.Apis.Sheets.v4.Data;
+using Moq;
+using RaptorSheets.Core.Models;
+using RaptorSheets.Core.Services;
+using RaptorSheets.Stock.Managers;
+using Xunit;
+
+namespace RaptorSheets.Stock.Tests.Unit.Managers;
+
+/// <summary>
+/// Covers the Stock-side wiring of the column auto-insertion feature (shared with Gig via
+/// RaptorSheets.Core.Helpers.ColumnInsertionHelper / RaptorSheets.Core.Registries.SheetRegistry).
+/// </summary>
+public class InsertMissingColumnsBehaviorTests
+{
+    [Fact]
+    public void CheckSheetHeaders_WithMissingColumn_DetectsInsertionInfo()
+    {
+        // Arrange - Stocks sheet is missing one of its expected headers
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new()
+                {
+                    Properties = new SheetProperties { Title = "Stocks", SheetId = 3 },
+                    Data =
+                    [
+                        new()
+                        {
+                            RowData = [new() { Values = [new() { FormattedValue = "Ticker" }] }]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // Act
+        var messages = GoogleSheetManager.CheckSheetHeaders(spreadsheet, out var missingColumns);
+
+        // Assert
+        Assert.NotEmpty(messages);
+        Assert.True(missingColumns.ContainsKey("Stocks"));
+        Assert.NotEmpty(missingColumns["Stocks"]);
+        Assert.All(missingColumns["Stocks"], c => Assert.Equal(3, c.SheetId));
+    }
+
+    [Fact]
+    public async Task InsertMissingColumns_WithNoMissingColumns_DoesNotCallService()
+    {
+        // Arrange
+        var mockService = new Mock<IGoogleSheetService>();
+        var manager = new GoogleSheetManager(mockService.Object);
+
+        // Act
+        var result = await manager.InsertMissingColumns([]);
+
+        // Assert
+        Assert.Contains(result.Messages, m => m.Message.Contains("No missing columns to insert"));
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InsertMissingColumns_WithMissingColumn_CallsBatchUpdateAndReportsSuccess()
+    {
+        // Arrange
+        var mockService = new Mock<IGoogleSheetService>();
+        mockService
+            .Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>()))
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new GoogleSheetManager(mockService.Object);
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Stocks"] = [new ColumnInsertionInfo { SheetName = "Stocks", SheetId = 3, ColumnIndex = 1, ColumnName = "Name" }]
+        };
+
+        // Act
+        var result = await manager.InsertMissingColumns(missingColumns);
+
+        // Assert
+        Assert.Contains(result.Messages, m => m.Message.Contains("Successfully inserted 1 missing column(s)"));
+    }
+}

--- a/RaptorSheets.Stock/Entities/SheetEntity.cs
+++ b/RaptorSheets.Stock/Entities/SheetEntity.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace RaptorSheets.Stock.Entities;
 
-public class SheetEntity
+public class SheetEntity : ISheetEntity
 {
     [JsonPropertyName("properties")]
     public PropertyEntity Properties { get; set; } = new();

--- a/RaptorSheets.Stock/Helpers/StockSheetHelpers.cs
+++ b/RaptorSheets.Stock/Helpers/StockSheetHelpers.cs
@@ -1,6 +1,7 @@
 using Google.Apis.Sheets.v4.Data;
 using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Extensions;
+using RaptorSheets.Core.Models;
 using RaptorSheets.Core.Models.Google;
 using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Registries;
@@ -76,6 +77,16 @@ public static class StockSheetHelpers
     public static List<MessageEntity> CheckSheetHeaders(Spreadsheet spreadsheet)
     {
         return s_registry.CheckSheetHeaders(spreadsheet);
+    }
+
+    /// <summary>
+    /// Same as <see cref="CheckSheetHeaders(Spreadsheet)"/>, but also reports which columns are
+    /// missing entirely and where they should be inserted, for use with
+    /// <see cref="RaptorSheets.Core.Helpers.ColumnInsertionHelper"/>.
+    /// </summary>
+    public static List<MessageEntity> CheckSheetHeaders(Spreadsheet spreadsheet, out Dictionary<string, List<ColumnInsertionInfo>> missingColumns)
+    {
+        return s_registry.CheckSheetHeaders(spreadsheet, out missingColumns);
     }
 
     public static SheetModel? GetSheetLayout(string sheetName)

--- a/RaptorSheets.Stock/Helpers/StockSheetHelpers.cs
+++ b/RaptorSheets.Stock/Helpers/StockSheetHelpers.cs
@@ -89,6 +89,15 @@ public static class StockSheetHelpers
         return s_registry.CheckSheetHeaders(spreadsheet, out missingColumns);
     }
 
+    /// <summary>
+    /// Detects columns missing entirely from a batchGet response, reusing the header row already
+    /// present in each range - no extra API call. SheetId is left at 0; the caller fills it in.
+    /// </summary>
+    public static Dictionary<string, List<ColumnInsertionInfo>> DetectMissingColumns(BatchGetValuesByDataFilterResponse response)
+    {
+        return s_registry.DetectMissingColumns(response);
+    }
+
     public static SheetModel? GetSheetLayout(string sheetName)
     {
         return s_registry.GetSheetLayout(sheetName);

--- a/RaptorSheets.Stock/Helpers/StockSheetHelpers.cs
+++ b/RaptorSheets.Stock/Helpers/StockSheetHelpers.cs
@@ -2,10 +2,11 @@ using Google.Apis.Sheets.v4.Data;
 using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Models.Google;
 using RaptorSheets.Core.Helpers;
+using RaptorSheets.Core.Registries;
+using RaptorSheets.Stock.Constants;
 using RaptorSheets.Stock.Enums;
 using RaptorSheets.Stock.Mappers;
 using RaptorSheets.Stock.Entities;
-using RaptorSheets.Stock.Constants;
 
 namespace RaptorSheets.Stock.Helpers;
 
@@ -23,39 +24,40 @@ public static class StockSheetHelpers
         return sheets;
     }
 
+    private static readonly SheetRegistry<SheetEntity> s_registry = BuildRegistry();
+
+    private static SheetRegistry<SheetEntity> BuildRegistry()
+    {
+        var registry = new SheetRegistry<SheetEntity>();
+
+        registry.Register(SheetEnum.ACCOUNTS.GetDescription(), () => SheetsConfig.AccountSheet, (se, values) =>
+        {
+            var headers = values[0];
+            se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, SheetsConfig.AccountSheet));
+            se.Accounts = AccountMapper.MapFromRangeData(values);
+        });
+
+        registry.Register(SheetEnum.STOCKS.GetDescription(), () => SheetsConfig.StockSheet, (se, values) =>
+        {
+            var headers = values[0];
+            se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, SheetsConfig.StockSheet));
+            se.Stocks = StockMapper.MapFromRangeData(values);
+        });
+
+        registry.Register(SheetEnum.TICKERS.GetDescription(), () => SheetsConfig.TickerSheet, (se, values) =>
+        {
+            var headers = values[0];
+            se.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, SheetsConfig.TickerSheet));
+            se.Tickers = TickerMapper.MapFromRangeData(values);
+        });
+
+        return registry;
+    }
+
     public static List<SheetModel> GetMissingSheets(Spreadsheet spreadsheet)
     {
-        var spreadsheetSheets = spreadsheet.Sheets.Select(x => x.Properties.Title.ToUpper()).ToList();
-        var sheetData = new List<SheetModel>();
-
-        // Loop through all sheets to see if they exist.
-        foreach (var name in Enum.GetNames<SheetEnum>())
-        {
-            SheetEnum sheetEnum = (SheetEnum)Enum.Parse(typeof(SheetEnum), name);
-
-            if (spreadsheetSheets.Contains(name))
-            {
-                continue;
-            }
-
-            // Get data for each missing sheet.
-            switch (sheetEnum)
-            {
-                case SheetEnum.ACCOUNTS:
-                    sheetData.Add(AccountMapper.GetSheet());
-                    break;
-                case SheetEnum.STOCKS:
-                    sheetData.Add(StockMapper.GetSheet());
-                    break;
-                case SheetEnum.TICKERS:
-                    sheetData.Add(TickerMapper.GetSheet());
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        return sheetData;
+        var canonicalNames = Enum.GetValues<SheetEnum>().Select(e => e.GetDescription());
+        return s_registry.GetMissingSheets(spreadsheet, canonicalNames);
     }
 
     public static DataValidationRule GetDataValidation(ValidationEnum validation)
@@ -91,39 +93,6 @@ public static class StockSheetHelpers
 
     public static SheetEntity? MapData(BatchGetValuesByDataFilterResponse response)
     {
-        if (response.ValueRanges == null)
-        {
-            return null;
-        }
-
-        var sheet = new SheetEntity();
-
-        // TODO: Figure out a better way to handle looping with message and entity mapping in the switch.
-        foreach (var matchedValue in response.ValueRanges)
-        {
-            var sheetRange = matchedValue.DataFilters[0].A1Range;
-            var values = matchedValue.ValueRange.Values;
-            var headers = values[0];
-
-            Enum.TryParse(sheetRange.ToUpper(), out SheetEnum sheetEnum);
-
-            switch (sheetEnum)
-            {
-                case SheetEnum.ACCOUNTS:
-                    sheet.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, SheetsConfig.AccountSheet));
-                    sheet.Accounts = AccountMapper.MapFromRangeData(values);
-                    break;
-                case SheetEnum.STOCKS:
-                    sheet.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, SheetsConfig.StockSheet));
-                    sheet.Stocks = StockMapper.MapFromRangeData(values);
-                    break;
-                case SheetEnum.TICKERS:
-                    sheet.Messages.AddRange(HeaderHelpers.CheckSheetHeaders(headers, SheetsConfig.TickerSheet));
-                    sheet.Tickers = TickerMapper.MapFromRangeData(values);
-                    break;
-            }
-        }
-
-        return sheet;
+        return s_registry.MapData(response);
     }
 }

--- a/RaptorSheets.Stock/Helpers/StockSheetHelpers.cs
+++ b/RaptorSheets.Stock/Helpers/StockSheetHelpers.cs
@@ -1,4 +1,5 @@
 using Google.Apis.Sheets.v4.Data;
+using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Models.Google;
 using RaptorSheets.Core.Helpers;
@@ -58,6 +59,33 @@ public static class StockSheetHelpers
     {
         var canonicalNames = Enum.GetValues<SheetEnum>().Select(e => e.GetDescription());
         return s_registry.GetMissingSheets(spreadsheet, canonicalNames);
+    }
+
+    /// <summary>
+    /// Checks a spreadsheet's tab names for sheets that don't correspond to any known Stock sheet.
+    /// Only needs sheet tab metadata (no grid/cell data).
+    /// </summary>
+    public static List<MessageEntity> CheckUnknownSheets(Spreadsheet spreadsheet)
+    {
+        return s_registry.CheckUnknownSheets(spreadsheet);
+    }
+
+    /// <summary>
+    /// Full header validation against grid-data (IncludeGridData=true) spreadsheet metadata.
+    /// </summary>
+    public static List<MessageEntity> CheckSheetHeaders(Spreadsheet spreadsheet)
+    {
+        return s_registry.CheckSheetHeaders(spreadsheet);
+    }
+
+    public static SheetModel? GetSheetLayout(string sheetName)
+    {
+        return s_registry.GetSheetLayout(sheetName);
+    }
+
+    public static List<SheetModel> GetSheetLayouts(IEnumerable<string> sheetNames)
+    {
+        return s_registry.GetSheetLayouts(sheetNames);
     }
 
     public static DataValidationRule GetDataValidation(ValidationEnum validation)

--- a/RaptorSheets.Stock/Managers/GoogleSheetManager.cs
+++ b/RaptorSheets.Stock/Managers/GoogleSheetManager.cs
@@ -1,10 +1,12 @@
 ﻿using Google.Apis.Sheets.v4.Data;
+using Microsoft.Extensions.Logging;
 using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Constants;
 using RaptorSheets.Core.Services;
 using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Helpers;
+using RaptorSheets.Core.Managers;
 using RaptorSheets.Stock.Entities;
 using RaptorSheets.Stock.Mappers;
 using RaptorSheets.Stock.Helpers;
@@ -25,18 +27,21 @@ public interface IGoogleSheetManager
     public List<SheetModel> GetSheetLayouts(List<string> sheets);
 }
 
-public class GoogleSheetManager : IGoogleSheetManager
+public class GoogleSheetManager : GoogleSheetManagerBase, IGoogleSheetManager
 {
-    private readonly GoogleSheetService _googleSheetService;
-
-    public GoogleSheetManager(string accessToken, string spreadsheetId)
+    public GoogleSheetManager(IGoogleSheetService googleSheetService, ILogger? logger = null)
+        : base(googleSheetService, logger)
     {
-        _googleSheetService = new GoogleSheetService(accessToken, spreadsheetId);
     }
 
-    public GoogleSheetManager(Dictionary<string, string> parameters, string spreadsheetId)
+    public GoogleSheetManager(string accessToken, string spreadsheetId, ILogger? logger = null)
+        : base(accessToken, spreadsheetId, logger)
     {
-        _googleSheetService = new GoogleSheetService(parameters, spreadsheetId);
+    }
+
+    public GoogleSheetManager(Dictionary<string, string> parameters, string spreadsheetId, ILogger? logger = null)
+        : base(parameters, spreadsheetId, logger)
+    {
     }
 
     public async Task<SheetEntity> AddSheetData(List<Enums.SheetEnum> sheets, SheetEntity sheetEntity)

--- a/RaptorSheets.Stock/Managers/GoogleSheetManager.cs
+++ b/RaptorSheets.Stock/Managers/GoogleSheetManager.cs
@@ -8,7 +8,6 @@ using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Managers;
 using RaptorSheets.Stock.Entities;
-using RaptorSheets.Stock.Mappers;
 using RaptorSheets.Stock.Helpers;
 using RaptorSheets.Core.Models.Google;
 using SheetEnum = RaptorSheets.Stock.Enums.SheetEnum;
@@ -91,50 +90,18 @@ public class GoogleSheetManager : GoogleSheetManagerBase, IGoogleSheetManager
         return sheetEntity;
     }
 
+    /// <summary>
+    /// Checks a spreadsheet's tab names for sheets that don't correspond to any known Stock sheet.
+    /// Only needs sheet tab metadata (no grid/cell data).
+    /// </summary>
+    public static List<MessageEntity> CheckUnknownSheets(Spreadsheet sheetInfoResponse)
+    {
+        return StockSheetHelpers.CheckUnknownSheets(sheetInfoResponse);
+    }
+
     public static List<MessageEntity> CheckSheetHeaders(Spreadsheet sheetInfoResponse)
     {
-        var messages = new List<MessageEntity>();
-
-        if (sheetInfoResponse == null)
-        {
-            messages.Add(MessageHelpers.CreateErrorMessage($"Unable to retrieve sheet(s)", MessageTypeEnum.GENERAL));
-            return messages;
-        }
-
-        var headerMessages = new List<MessageEntity>();
-        // Loop through sheets to check headers.
-        foreach (var sheet in sheetInfoResponse.Sheets)
-        {
-            var sheetEnum = (Enums.SheetEnum)Enum.Parse(typeof(Enums.SheetEnum), sheet.Properties.Title.ToUpper());
-            var sheetHeader = HeaderHelpers.GetHeadersFromCellData(sheet.Data?[0]?.RowData?[0]?.Values);
-
-            switch (sheetEnum)
-            {
-                case Enums.SheetEnum.ACCOUNTS:
-                    // headerMessages.AddRange(HeaderHelper.CheckSheetHeaders(sheetHeader, AccountMapper.GetSheet()));
-                    break;
-                case Enums.SheetEnum.STOCKS:
-                    headerMessages.AddRange(HeaderHelpers.CheckSheetHeaders(sheetHeader, StockMapper.GetSheet()));
-                    break;
-                case Enums.SheetEnum.TICKERS:
-                    // headerMessages.AddRange(HeaderHelper.CheckSheetHeaders(sheetHeader, TickerMapper.GetSheet()));
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        if (headerMessages.Count > 0)
-        {
-            messages.Add(MessageHelpers.CreateWarningMessage($"Found sheet header issue(s)", MessageTypeEnum.CHECK_SHEET));
-            messages.AddRange(headerMessages);
-        }
-        else
-        {
-            messages.Add(MessageHelpers.CreateInfoMessage($"No sheet header issues found", MessageTypeEnum.CHECK_SHEET));
-        }
-
-        return messages;
+        return StockSheetHelpers.CheckSheetHeaders(sheetInfoResponse);
     }
 
     public async Task<SheetEntity> CreateSheets()
@@ -246,23 +213,7 @@ public class GoogleSheetManager : GoogleSheetManagerBase, IGoogleSheetManager
     {
         try
         {
-            // Try to parse as enum
-            var sheetExists = Enum.TryParse(sheet.ToUpper(), out Enums.SheetEnum sheetEnum) 
-                && Enum.IsDefined(typeof(Enums.SheetEnum), sheetEnum);
-
-            if (!sheetExists)
-            {
-                return null;
-            }
-
-            // Get the appropriate mapper's sheet model
-            return sheetEnum switch
-            {
-                Enums.SheetEnum.ACCOUNTS => AccountMapper.GetSheet(),
-                Enums.SheetEnum.STOCKS => StockMapper.GetSheet(),
-                Enums.SheetEnum.TICKERS => TickerMapper.GetSheet(),
-                _ => null
-            };
+            return StockSheetHelpers.GetSheetLayout(sheet);
         }
         catch (Exception)
         {

--- a/RaptorSheets.Stock/Managers/GoogleSheetManager.cs
+++ b/RaptorSheets.Stock/Managers/GoogleSheetManager.cs
@@ -7,6 +7,7 @@ using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Managers;
+using RaptorSheets.Core.Models;
 using RaptorSheets.Stock.Entities;
 using RaptorSheets.Stock.Helpers;
 using RaptorSheets.Core.Models.Google;
@@ -24,6 +25,7 @@ public interface IGoogleSheetManager
     public Task<SheetEntity> GetSheets(List<Enums.SheetEnum> sheets);
     public SheetModel? GetSheetLayout(string sheet);
     public List<SheetModel> GetSheetLayouts(List<string> sheets);
+    public Task<SheetEntity> InsertMissingColumns(Dictionary<string, List<ColumnInsertionInfo>> missingColumns);
 }
 
 public class GoogleSheetManager : GoogleSheetManagerBase, IGoogleSheetManager
@@ -102,6 +104,24 @@ public class GoogleSheetManager : GoogleSheetManagerBase, IGoogleSheetManager
     public static List<MessageEntity> CheckSheetHeaders(Spreadsheet sheetInfoResponse)
     {
         return StockSheetHelpers.CheckSheetHeaders(sheetInfoResponse);
+    }
+
+    /// <summary>
+    /// Same as <see cref="CheckSheetHeaders(Spreadsheet)"/>, but also reports which columns are
+    /// missing entirely and where they should be inserted, for use with <see cref="InsertMissingColumns"/>.
+    /// </summary>
+    public static List<MessageEntity> CheckSheetHeaders(Spreadsheet sheetInfoResponse, out Dictionary<string, List<ColumnInsertionInfo>> missingColumns)
+    {
+        return StockSheetHelpers.CheckSheetHeaders(sheetInfoResponse, out missingColumns);
+    }
+
+    /// <summary>
+    /// Physically inserts columns detected as missing by <see cref="CheckSheetHeaders(Spreadsheet, out Dictionary{string, List{ColumnInsertionInfo}})"/>
+    /// at their expected position, and writes the header text into each newly-inserted column.
+    /// </summary>
+    public async Task<SheetEntity> InsertMissingColumns(Dictionary<string, List<ColumnInsertionInfo>> missingColumns)
+    {
+        return await ColumnInsertionHelper.InsertMissingColumnsAsync<SheetEntity>(_googleSheetService, missingColumns);
     }
 
     public async Task<SheetEntity> CreateSheets()

--- a/RaptorSheets.Stock/Managers/GoogleSheetManager.cs
+++ b/RaptorSheets.Stock/Managers/GoogleSheetManager.cs
@@ -188,6 +188,8 @@ public class GoogleSheetManager : GoogleSheetManagerBase, IGoogleSheetManager
 
         var response = await _googleSheetService.GetBatchData(sheets.Select(x => x.GetDescription()).ToList());
 
+        Spreadsheet? spreadsheetInfo = null;
+
         if (response == null)
         {
             messages.Add(MessageHelpers.CreateErrorMessage($"Unable to retrieve sheet(s): {stringSheetList}", MessageTypeEnum.GET_SHEETS));
@@ -196,6 +198,36 @@ public class GoogleSheetManager : GoogleSheetManagerBase, IGoogleSheetManager
         {
             messages.Add(MessageHelpers.CreateInfoMessage($"Retrieved sheet(s): {stringSheetList}", MessageTypeEnum.GET_SHEETS));
             data = StockSheetHelpers.MapData(response);
+
+            // Auto-heal: insert any expected INPUT columns missing entirely, at their correct
+            // canonical position (not appended at the end). HideHeaderName columns (populated by a
+            // spilling QUERY formula) are never candidates - HeaderHelpers.CheckSheetHeaders already
+            // excludes them. Detection reuses the header row already in `response` (no extra API
+            // call); a metadata fetch for SheetId only happens when something is actually missing
+            // (rare), and is reused below for the spreadsheet-name lookup if needed.
+            var missingColumns = StockSheetHelpers.DetectMissingColumns(response);
+            if (missingColumns.Count > 0)
+            {
+                spreadsheetInfo = await _googleSheetService.GetSheetInfo();
+
+                if (spreadsheetInfo?.Sheets != null)
+                {
+                    foreach (var (sheetName, columns) in missingColumns)
+                    {
+                        var sheetId = spreadsheetInfo.Sheets
+                            .FirstOrDefault(s => string.Equals(s.Properties.Title, sheetName, StringComparison.OrdinalIgnoreCase))
+                            ?.Properties.SheetId ?? 0;
+
+                        foreach (var column in columns)
+                        {
+                            column.SheetId = sheetId;
+                        }
+                    }
+
+                    var insertResult = await InsertMissingColumns(missingColumns);
+                    messages.AddRange(insertResult.Messages);
+                }
+            }
         }
 
         // Only get spreadsheet name when all sheets are requested.
@@ -205,7 +237,7 @@ public class GoogleSheetManager : GoogleSheetManagerBase, IGoogleSheetManager
             return data;
         }
 
-        var spreadsheet = await _googleSheetService.GetSheetInfo();
+        var spreadsheet = spreadsheetInfo ?? await _googleSheetService.GetSheetInfo();
         var spreadsheetName = SheetHelpers.GetSpreadsheetTitle(spreadsheet);
 
         if (string.IsNullOrEmpty(spreadsheetName))


### PR DESCRIPTION
## Summary

Three connected pieces of work, all building toward less duplication between domain packages (Gig, Stock, and future ones like Job) without generalizing the entities themselves.

### 1. Shared `GoogleSheetManagerBase` + `SheetRegistry<T>` in Core
- `GoogleSheetManagerBase` (`RaptorSheets.Core.Managers`): the constructor/DI/logger boilerplate every domain manager was hand-rolling identically. Stock gains a DI constructor and logger support it didn't have before.
- `SheetRegistry<TEntity>` (`RaptorSheets.Core.Registries`): generic `MapData`/`GetMissingSheets` orchestration over a per-sheet `name -> (SheetModel factory, row processor)` registration, plus a `RegisterGeneric` helper for the common `GenericSheetMapper<T>` case. Each domain still owns its own strongly-typed entities and mappers — nothing becomes a generic Cell/Row model.
- `GigSheetHelpers`/`StockSheetHelpers` now build a registry once and delegate to it; public API of both is unchanged.
- Net **-189 lines** across Gig + Stock.

### 2. Generalized header/unknown-sheet checking into the registry
- `CheckSheetHeaders`/`CheckUnknownSheets`/`GetSheetLayout(s)` moved onto `SheetRegistry<T>`, since they only need the registry's existing sheet-name → `SheetModel` map.
- **Bug fix along the way**: Stock's `CheckSheetHeaders` had two dead switch cases (`ACCOUNTS`/`TICKERS` commented out), so those sheets' headers were silently never validated. Routing through the shared registry fixes this for free — added a test confirming a mismatched Accounts header is now actually caught.
- Gig's `GoogleSheetManager.Metadata.cs` shrank by 112 lines.

### 3. Missing-column auto-detection and insertion
Finishes work found abandoned on the unmerged `story/issue-improvements` branch (commit `5b12306`, never reached `main`, diverged too far to cherry-pick cleanly) — reimplemented against the `SheetRegistry<T>` architecture above so it's available to every domain, not just Gig.

- `HeaderHelpers.CheckSheetHeaders(values, sheetModel, out insertionInfo)`: new overload reporting which expected columns are missing entirely, and the index they belong at (canonical header order — never appended at the end).
- `ColumnInsertionHelper` (Core): builds and executes the insert+update batch request, right-to-left per sheet so earlier insertions don't shift later ones.
- `GoogleSheetManager.GetSheets` (Gig + Stock): now auto-detects and inserts genuinely-missing columns using data already in hand — no extra API call for detection, and the actual insert only fires when something's really missing.

**Two real bugs found and fixed while reimplementing:**
- The original ported code always wrote the new column's header text to column 0 regardless of where it was actually inserted (`GenerateUpdateCellsRequest` had no column-index parameter) — fixed with an explicit `startColumnIndex`.
- Testing against the live integration spreadsheet surfaced that columns populated by a spilling `QUERY()` formula (e.g. Delivery/Location's `Pay`/`Tips`/`Bonus`/`Total`/`Distance`/`First Trip`/`Last Trip`, marked `HideHeaderName`) were being wrongly treated as insertion candidates — inserting a bare header-only column into those would land inside the query's contiguous spill range and break it. Detection now explicitly skips any `HideHeaderName` column.

## Test plan
- Full solution suite: 861 Core, 25 Stock, 587 Gig (non-integration), all green.
- 23+ new tests covering: registry `MapData`/`GetMissingSheets`/`CheckSheetHeaders`/`CheckUnknownSheets`, `ColumnInsertionInfo` detection (including the `HideHeaderName` exclusion), `ColumnInsertionHelper` request building/ordering/execution (mocked `IGoogleSheetService`), and manager-level wiring for both Gig and Stock.
- Live `GoogleSheetsIntegrationTests` against the real test spreadsheet re-verified individually after the fixes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)