### PR TITLE
Home: combine Doors into Doors & Windows, add demo data

### DIFF
--- a/RaptorSheets.Home.Tests/Integration/HomeSheetsIntegrationTests.cs
+++ b/RaptorSheets.Home.Tests/Integration/HomeSheetsIntegrationTests.cs
@@ -60,6 +60,24 @@ public class HomeSheetsIntegrationTests : IntegrationTestBase
         Assert.False(string.IsNullOrWhiteSpace(fridge!.NextFilter));
     }
 
+    [FactCheckUserSecrets]
+    public async Task SetupDemo_CreatesSheetsAndPopulatesData()
+    {
+        SkipIfNoCredentials();
+
+        var result = await GoogleSheetManager!.SetupDemo(seed: 42);
+
+        Assert.NotEmpty(result.Sheets.Rooms);
+        Assert.NotEmpty(result.Sheets.DoorsWindows);
+        Assert.NotEmpty(result.Sheets.Stats);
+
+        await Task.Delay(2500);
+
+        var readBack = await GoogleSheetManager!.GetSheets([SheetsConfig.SheetNames.Rooms, SheetsConfig.SheetNames.Stats]);
+        Assert.NotEmpty(readBack.Sheets.Rooms);
+        Assert.Contains(readBack.Sheets.Stats, s => s.Name == "Roof Type");
+    }
+
     private static SheetEntity BuildTestData()
     {
         var data = new SheetEntity();

--- a/RaptorSheets.Home/Constants/SheetsConfig.cs
+++ b/RaptorSheets.Home/Constants/SheetsConfig.cs
@@ -21,7 +21,7 @@ public static class SheetsConfig
         public const string Appliances = "Appliances & Electronics";
         public const string Projects = "Projects";
         public const string Maintenance = "Maintenance Log";
-        public const string Doors = "Doors";
+        public const string DoorsWindows = "Doors & Windows";
         public const string Paints = "Paints";
         public const string Power = "Power";
 
@@ -90,7 +90,7 @@ public static class SheetsConfig
         public const string SquareFeet = "Sq. Ft";
         public const string Level = "Level";
 
-        // Doors
+        // Doors & Windows
         public const string Width = "Width";
         public const string Height = "Height";
         public const string Depth = "Depth";
@@ -137,7 +137,7 @@ public static class SheetsConfig
             SheetNames.Appliances,
             SheetNames.Projects,
             SheetNames.Maintenance,
-            SheetNames.Doors,
+            SheetNames.DoorsWindows,
             SheetNames.Paints,
             SheetNames.Power,
 

--- a/RaptorSheets.Home/Entities/DoorWindowEntity.cs
+++ b/RaptorSheets.Home/Entities/DoorWindowEntity.cs
@@ -6,8 +6,13 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace RaptorSheets.Home.Entities;
 
+/// <summary>
+/// Covers both doors and windows - they share the same shape (a dimensioned opening/fixture with a
+/// brand, model, and install date), so one sheet holds both. <see cref="Type"/> is free text (e.g.
+/// "Front Door", "Bay Window", "Sliding Door") and is what distinguishes the two.
+/// </summary>
 [ExcludeFromCodeCoverage]
-public class DoorEntity : SheetRowEntityBase
+public class DoorWindowEntity : SheetRowEntityBase
 {
     [Column(SheetsConfig.HeaderNames.Location, isInput: true, enableValidation: true, validationPattern: SheetsConfig.ValidationNames.RangeRoom)]
     public string Location { get; set; } = "";

--- a/RaptorSheets.Home/Entities/HomeSheets.cs
+++ b/RaptorSheets.Home/Entities/HomeSheets.cs
@@ -21,8 +21,8 @@ public class HomeSheets
     [JsonPropertyName("maintenance")]
     public List<MaintenanceEntity> Maintenance { get; set; } = [];
 
-    [JsonPropertyName("doors")]
-    public List<DoorEntity> Doors { get; set; } = [];
+    [JsonPropertyName("doorsWindows")]
+    public List<DoorWindowEntity> DoorsWindows { get; set; } = [];
 
     [JsonPropertyName("paints")]
     public List<PaintEntity> Paints { get; set; } = [];

--- a/RaptorSheets.Home/Enums/SheetName.cs
+++ b/RaptorSheets.Home/Enums/SheetName.cs
@@ -18,8 +18,8 @@ public enum SheetName
     [Description(SheetsConfig.SheetNames.Maintenance)]
     MAINTENANCE,
 
-    [Description(SheetsConfig.SheetNames.Doors)]
-    DOORS,
+    [Description(SheetsConfig.SheetNames.DoorsWindows)]
+    DOORS_WINDOWS,
 
     [Description(SheetsConfig.SheetNames.Paints)]
     PAINTS,

--- a/RaptorSheets.Home/Helpers/GenerateSheetsHelpers.cs
+++ b/RaptorSheets.Home/Helpers/GenerateSheetsHelpers.cs
@@ -29,7 +29,7 @@ public static class GenerateSheetsHelpers
             var s when string.Equals(s, SheetsConfig.SheetNames.Appliances, StringComparison.OrdinalIgnoreCase) => ApplianceSheet.GetSheet(),
             var s when string.Equals(s, SheetsConfig.SheetNames.Projects, StringComparison.OrdinalIgnoreCase) => ProjectSheet.GetSheet(),
             var s when string.Equals(s, SheetsConfig.SheetNames.Maintenance, StringComparison.OrdinalIgnoreCase) => MaintenanceSheet.GetSheet(),
-            var s when string.Equals(s, SheetsConfig.SheetNames.Doors, StringComparison.OrdinalIgnoreCase) => DoorSheet.GetSheet(),
+            var s when string.Equals(s, SheetsConfig.SheetNames.DoorsWindows, StringComparison.OrdinalIgnoreCase) => DoorWindowSheet.GetSheet(),
             var s when string.Equals(s, SheetsConfig.SheetNames.Paints, StringComparison.OrdinalIgnoreCase) => PaintSheet.GetSheet(),
             var s when string.Equals(s, SheetsConfig.SheetNames.Power, StringComparison.OrdinalIgnoreCase) => PowerSheet.GetSheet(),
             var s when string.Equals(s, SheetsConfig.SheetNames.Rooms, StringComparison.OrdinalIgnoreCase) => RoomSheet.GetSheet(),

--- a/RaptorSheets.Home/Helpers/HomeRequestHelpers.cs
+++ b/RaptorSheets.Home/Helpers/HomeRequestHelpers.cs
@@ -28,10 +28,10 @@ public static class HomeRequestHelpers
         => GoogleRequestHelpers.ChangeSheetData(maintenance, sheetProperties, (entities, props) =>
             GoogleRequestHelpers.CreateUpdateCellRequests(entities, props, GenericSheetMapper<MaintenanceEntity>.MapToRowData));
 
-    // DOORS
-    public static List<Request> ChangeDoorSheetData(List<DoorEntity> doors, PropertyEntity? sheetProperties)
-        => GoogleRequestHelpers.ChangeSheetData(doors, sheetProperties, (entities, props) =>
-            GoogleRequestHelpers.CreateUpdateCellRequests(entities, props, GenericSheetMapper<DoorEntity>.MapToRowData));
+    // DOORS & WINDOWS
+    public static List<Request> ChangeDoorWindowSheetData(List<DoorWindowEntity> doorsWindows, PropertyEntity? sheetProperties)
+        => GoogleRequestHelpers.ChangeSheetData(doorsWindows, sheetProperties, (entities, props) =>
+            GoogleRequestHelpers.CreateUpdateCellRequests(entities, props, GenericSheetMapper<DoorWindowEntity>.MapToRowData));
 
     // PAINTS
     public static List<Request> ChangePaintSheetData(List<PaintEntity> paints, PropertyEntity? sheetProperties)

--- a/RaptorSheets.Home/Helpers/HomeSheetHelpers.cs
+++ b/RaptorSheets.Home/Helpers/HomeSheetHelpers.cs
@@ -40,7 +40,7 @@ public static class HomeSheetHelpers
         registry.RegisterGeneric<SheetEntity, ApplianceEntity>(SheetsConfig.SheetNames.Appliances, ApplianceSheet.GetSheet, (se, rows) => se.Sheets.Appliances = rows);
         registry.RegisterGeneric<SheetEntity, ProjectEntity>(SheetsConfig.SheetNames.Projects, ProjectSheet.GetSheet, (se, rows) => se.Sheets.Projects = rows);
         registry.RegisterGeneric<SheetEntity, MaintenanceEntity>(SheetsConfig.SheetNames.Maintenance, MaintenanceSheet.GetSheet, (se, rows) => se.Sheets.Maintenance = rows);
-        registry.RegisterGeneric<SheetEntity, DoorEntity>(SheetsConfig.SheetNames.Doors, DoorSheet.GetSheet, (se, rows) => se.Sheets.Doors = rows);
+        registry.RegisterGeneric<SheetEntity, DoorWindowEntity>(SheetsConfig.SheetNames.DoorsWindows, DoorWindowSheet.GetSheet, (se, rows) => se.Sheets.DoorsWindows = rows);
         registry.RegisterGeneric<SheetEntity, PaintEntity>(SheetsConfig.SheetNames.Paints, PaintSheet.GetSheet, (se, rows) => se.Sheets.Paints = rows);
         registry.RegisterGeneric<SheetEntity, PowerEntity>(SheetsConfig.SheetNames.Power, PowerSheet.GetSheet, (se, rows) => se.Sheets.Power = rows);
         registry.RegisterGeneric<SheetEntity, RoomEntity>(SheetsConfig.SheetNames.Rooms, RoomSheet.GetSheet, (se, rows) => se.Sheets.Rooms = rows);

--- a/RaptorSheets.Home/Managers/GoogleSheetManager.cs
+++ b/RaptorSheets.Home/Managers/GoogleSheetManager.cs
@@ -38,6 +38,11 @@ public interface IGoogleSheetManager
 
     // Header Management
     Task<SheetEntity> InsertMissingColumns(Dictionary<string, List<ColumnInsertionInfo>> missingColumns);
+
+    // Demo Data Generation
+    Task<SheetEntity> SetupDemo(int? seed = null);
+    Task<SheetEntity> PopulateDemoData(int? seed = null);
+    SheetEntity GenerateDemoData(int? seed = null);
 }
 
 /// <summary>
@@ -208,6 +213,130 @@ public class GoogleSheetManager : GoogleSheetManagerBase<SheetEntity>, IGoogleSh
     public static List<MessageEntity> CheckSheetHeaders(Spreadsheet sheetInfoResponse, out Dictionary<string, List<ColumnInsertionInfo>> missingColumns)
     {
         return HomeSheetHelpers.CheckSheetHeaders(sheetInfoResponse, out missingColumns);
+    }
+
+    #endregion
+
+    #region Demo Data Generation
+
+    /// <summary>
+    /// Creates all sheets and then fills every sheet with a realistic sample household's worth of
+    /// demo data.
+    /// </summary>
+    public async Task<SheetEntity> SetupDemo(int? seed = null)
+    {
+        await CreateAllSheets();
+        await Task.Delay(1500); // let freshly-created sheets become writable
+        return await PopulateDemoData(seed);
+    }
+
+    /// <summary>
+    /// Writes generated demo data into every Home sheet in a single batch. Unlike Stock/Gig/Job,
+    /// every Home sheet is directly user-entered (none are formula-derived from another), so all
+    /// nine get written here rather than just one or two input sheets.
+    /// </summary>
+    public async Task<SheetEntity> PopulateDemoData(int? seed = null)
+    {
+        var demoData = GenerateDemoData(seed);
+
+        var sheetsToWrite = new List<string>
+        {
+            SheetsConfig.SheetNames.Rooms,
+            SheetsConfig.SheetNames.Contacts,
+            SheetsConfig.SheetNames.Appliances,
+            SheetsConfig.SheetNames.Projects,
+            SheetsConfig.SheetNames.Maintenance,
+            SheetsConfig.SheetNames.DoorsWindows,
+            SheetsConfig.SheetNames.Paints,
+            SheetsConfig.SheetNames.Power,
+            SheetsConfig.SheetNames.Stats
+        };
+
+        await ChangeSheetData(sheetsToWrite, demoData);
+        return demoData;
+    }
+
+    /// <summary>
+    /// Generates a small, realistic sample household's worth of data across every Home sheet,
+    /// without writing it anywhere. RowIds start at 2 (per sheet) so a subsequent write lands rows
+    /// below the header row. Deliberately a fixed, curated set rather than randomly generated volume
+    /// (unlike Gig/Job's demo data) - the goal is a clean example a user can look at and edit, not a
+    /// large synthetic dataset. <paramref name="seed"/> is accepted for API consistency with the
+    /// other domains' demo-data methods but isn't currently used.
+    /// </summary>
+    public SheetEntity GenerateDemoData(int? seed = null)
+    {
+        const string livingRoom = "Living Room";
+        const string kitchen = "Kitchen";
+        const string garage = "Garage";
+
+        var sheetEntity = new SheetEntity();
+
+        sheetEntity.Sheets.Rooms.AddRange(
+        [
+            new RoomEntity { RowId = 2, Room = livingRoom, Length = 15, Width = 12, Level = "Main" },
+            new RoomEntity { RowId = 3, Room = kitchen, Length = 12, Width = 10, Level = "Main" },
+            new RoomEntity { RowId = 4, Room = "Primary Bedroom", Length = 14, Width = 13, Level = "Upper" },
+            new RoomEntity { RowId = 5, Room = "Bathroom", Length = 8, Width = 6, Level = "Upper" },
+            new RoomEntity { RowId = 6, Room = garage, Length = 20, Width = 20, Level = "Main" }
+        ]);
+
+        sheetEntity.Sheets.Contacts.AddRange(
+        [
+            new ContactEntity { RowId = 2, Name = "Ace Plumbing", Number = "555-0100", Description = "Plumber" },
+            new ContactEntity { RowId = 3, Name = "Bright Spark Electric", Number = "555-0111", Description = "Electrician" },
+            new ContactEntity { RowId = 4, Name = "Cool Breeze HVAC", Number = "555-0122", Description = "HVAC Technician" }
+        ]);
+
+        sheetEntity.Sheets.Appliances.AddRange(
+        [
+            new ApplianceEntity { RowId = 2, Type = "Refrigerator", Location = kitchen, Manufacturer = "LG", Model = "LRFVS3006S", FilterDate = "2026-01-15", ReplacementMonths = 6, OriginalPrice = 1899.99m },
+            new ApplianceEntity { RowId = 3, Type = "Washer", Location = garage, Manufacturer = "Samsung", Model = "WF45T6000AW", OriginalPrice = 749.99m },
+            new ApplianceEntity { RowId = 4, Type = "Furnace", Location = garage, Manufacturer = "Carrier", Model = "59SC5", FilterDate = "2026-02-01", ReplacementMonths = 3, OriginalPrice = 3200.00m }
+        ]);
+
+        sheetEntity.Sheets.Projects.AddRange(
+        [
+            new ProjectEntity { RowId = 2, Task = "Repaint Living Room", Area = livingRoom, Started = "2026-03-01", Completed = "2026-03-05", ApproximateCost = 250.00m },
+            new ProjectEntity { RowId = 3, Task = "Install Ceiling Fan", Area = "Primary Bedroom", Started = "2026-04-10", ApproximateCost = 180.00m }
+        ]);
+
+        sheetEntity.Sheets.Maintenance.AddRange(
+        [
+            new MaintenanceEntity { RowId = 2, Date = "2026-02-14", Problem = "Leaky kitchen faucet", CompanyPerson = "Ace Plumbing", Solution = "Replaced cartridge", Amount = 145.00m },
+            new MaintenanceEntity { RowId = 3, Date = "2026-05-02", Problem = "Outlet not working", CompanyPerson = "Bright Spark Electric", Solution = "Replaced GFI outlet", Amount = 95.00m }
+        ]);
+
+        sheetEntity.Sheets.DoorsWindows.AddRange(
+        [
+            new DoorWindowEntity { RowId = 2, Location = livingRoom, Type = "Front Door", Brand = "Therma-Tru", Installed = "2018-06-01" },
+            new DoorWindowEntity { RowId = 3, Location = kitchen, Type = "Sliding Door", Brand = "Andersen", Installed = "2018-06-01" },
+            new DoorWindowEntity { RowId = 4, Location = livingRoom, Type = "Bay Window", Brand = "Pella", Installed = "2015-09-12" }
+        ]);
+
+        sheetEntity.Sheets.Paints.AddRange(
+        [
+            new PaintEntity { RowId = 2, Brand = "Sherwin-Williams", Type = "Eggshell", Color = "Agreeable Gray", Location = livingRoom, Remaining = "3/4 gallon", Size = "1 gallon" },
+            new PaintEntity { RowId = 3, Brand = "Benjamin Moore", Type = "Satin", Color = "White Dove", Location = kitchen, Remaining = "1/2 gallon", Size = "1 gallon" }
+        ]);
+
+        sheetEntity.Sheets.Power.AddRange(
+        [
+            new PowerEntity { RowId = 2, Location = kitchen, Type = "Outlet", Position = "Countertop", Amps = 20, Grounded = true, GFI = true },
+            new PowerEntity { RowId = 3, Location = garage, Type = "Outlet", Position = "Workbench", Amps = 20, Grounded = true, GFI = true }
+        ]);
+
+        sheetEntity.Sheets.Stats.AddRange(
+        [
+            new StatEntity { RowId = 2, Name = "Beds", Value = "3" },
+            new StatEntity { RowId = 3, Name = "Baths", Value = "2" },
+            new StatEntity { RowId = 4, Name = "Built", Value = "1998" },
+            new StatEntity { RowId = 5, Name = "Square Footage", Value = "2400" },
+            new StatEntity { RowId = 6, Name = "Roof Type", Value = "Asphalt Shingle" },
+            new StatEntity { RowId = 7, Name = "Roof Installed", Value = "2015" }
+        ]);
+
+        return sheetEntity;
     }
 
     #endregion

--- a/RaptorSheets.Home/Managers/GoogleSheetManager.cs
+++ b/RaptorSheets.Home/Managers/GoogleSheetManager.cs
@@ -278,7 +278,9 @@ public class GoogleSheetManager : GoogleSheetManagerBase<SheetEntity>, IGoogleSh
             new RoomEntity { RowId = 3, Room = kitchen, Length = 12, Width = 10, Level = "Main" },
             new RoomEntity { RowId = 4, Room = "Primary Bedroom", Length = 14, Width = 13, Level = "Upper" },
             new RoomEntity { RowId = 5, Room = "Bathroom", Length = 8, Width = 6, Level = "Upper" },
-            new RoomEntity { RowId = 6, Room = garage, Length = 20, Width = 20, Level = "Main" }
+            new RoomEntity { RowId = 6, Room = garage, Length = 20, Width = 20, Level = "Main" },
+            // Detached structures use Level to say so, instead of a floor like Main/Upper
+            new RoomEntity { RowId = 7, Room = "Shed", Length = 10, Width = 8, Level = "Shed" }
         ]);
 
         sheetEntity.Sheets.Contacts.AddRange(
@@ -292,7 +294,11 @@ public class GoogleSheetManager : GoogleSheetManagerBase<SheetEntity>, IGoogleSh
         [
             new ApplianceEntity { RowId = 2, Type = "Refrigerator", Location = kitchen, Manufacturer = "LG", Model = "LRFVS3006S", FilterDate = "2026-01-15", ReplacementMonths = 6, OriginalPrice = 1899.99m },
             new ApplianceEntity { RowId = 3, Type = "Washer", Location = garage, Manufacturer = "Samsung", Model = "WF45T6000AW", OriginalPrice = 749.99m },
-            new ApplianceEntity { RowId = 4, Type = "Furnace", Location = garage, Manufacturer = "Carrier", Model = "59SC5", FilterDate = "2026-02-01", ReplacementMonths = 3, OriginalPrice = 3200.00m }
+            new ApplianceEntity { RowId = 4, Type = "Furnace", Location = garage, Manufacturer = "Carrier", Model = "59SC5", FilterDate = "2026-02-01", ReplacementMonths = 3, OriginalPrice = 3200.00m },
+            // Whole-property energy systems fit the same generic shape (EnergySource/Capacity cover
+            // what Filter/FilterDate cover for appliances that need it instead)
+            new ApplianceEntity { RowId = 5, Type = "Solar Panel System", Manufacturer = "SunPower", Model = "X22-370", EnergySource = "Solar", Capacity = "6.5 kW", OriginalPrice = 18500.00m },
+            new ApplianceEntity { RowId = 6, Type = "Generator", Location = garage, Manufacturer = "Generac", Model = "Guardian 22kW", EnergySource = "Propane", Capacity = "22 kW", OriginalPrice = 4500.00m }
         ]);
 
         sheetEntity.Sheets.Projects.AddRange(
@@ -333,7 +339,10 @@ public class GoogleSheetManager : GoogleSheetManagerBase<SheetEntity>, IGoogleSh
             new StatEntity { RowId = 4, Name = "Built", Value = "1998" },
             new StatEntity { RowId = 5, Name = "Square Footage", Value = "2400" },
             new StatEntity { RowId = 6, Name = "Roof Type", Value = "Asphalt Shingle" },
-            new StatEntity { RowId = 7, Name = "Roof Installed", Value = "2015" }
+            new StatEntity { RowId = 7, Name = "Roof Installed", Value = "2015" },
+            // A second structure's roof is just another name/value pair - Stats isn't limited to one
+            // of each fact
+            new StatEntity { RowId = 8, Name = "Shed Roof Type", Value = "Metal" }
         ]);
 
         return sheetEntity;

--- a/RaptorSheets.Home/Managers/GoogleSheetManager.cs
+++ b/RaptorSheets.Home/Managers/GoogleSheetManager.cs
@@ -139,10 +139,10 @@ public class GoogleSheetManager : GoogleSheetManagerBase<SheetEntity>, IGoogleSh
                 entity => entity.Sheets.Maintenance.Count,
                 entity => entity.Sheets.Maintenance,
                 (data, properties) => HomeRequestHelpers.ChangeMaintenanceSheetData(data as List<MaintenanceEntity> ?? [], properties)),
-            [SheetsConfig.SheetNames.Doors] = new(
-                entity => entity.Sheets.Doors.Count,
-                entity => entity.Sheets.Doors,
-                (data, properties) => HomeRequestHelpers.ChangeDoorSheetData(data as List<DoorEntity> ?? [], properties)),
+            [SheetsConfig.SheetNames.DoorsWindows] = new(
+                entity => entity.Sheets.DoorsWindows.Count,
+                entity => entity.Sheets.DoorsWindows,
+                (data, properties) => HomeRequestHelpers.ChangeDoorWindowSheetData(data as List<DoorWindowEntity> ?? [], properties)),
             [SheetsConfig.SheetNames.Paints] = new(
                 entity => entity.Sheets.Paints.Count,
                 entity => entity.Sheets.Paints,

--- a/RaptorSheets.Home/Sheets/DoorWindowSheet.cs
+++ b/RaptorSheets.Home/Sheets/DoorWindowSheet.cs
@@ -8,22 +8,22 @@ using RaptorSheets.Home.Entities;
 namespace RaptorSheets.Home.Sheets;
 
 /// <summary>
-/// Door sheet definition. Entirely entity-driven, no custom formulas.
+/// Doors &amp; Windows sheet definition. Entirely entity-driven, no custom formulas.
 /// </summary>
-public static class DoorSheet
+public static class DoorWindowSheet
 {
     internal static SheetModel BaseSheet => new()
     {
-        Name = SheetsConfig.SheetNames.Doors,
+        Name = SheetsConfig.SheetNames.DoorsWindows,
         TabColor = SheetColor.DARK_YELLOW,
         CellColor = SheetColor.LIGHT_YELLOW,
         FreezeColumnCount = 1,
         FreezeRowCount = 1,
-        Headers = EntitySheetConfigHelper.GenerateHeadersFromEntity<DoorEntity>()
+        Headers = EntitySheetConfigHelper.GenerateHeadersFromEntity<DoorWindowEntity>()
     };
 
     public static SheetModel GetSheet()
     {
-        return GenericSheetMapper<DoorEntity>.GetSheet(BaseSheet);
+        return GenericSheetMapper<DoorWindowEntity>.GetSheet(BaseSheet);
     }
 }


### PR DESCRIPTION
## Summary
- Combines Home's `Doors` sheet into **Doors & Windows** - doors and windows share the same shape (room-located, dimensioned fixture with brand/model/install date), so they now live in one sheet instead of only having a Doors sheet with no Windows equivalent. `Type` stays free text (e.g. "Front Door", "Bay Window") to distinguish the two rather than adding a new validation/dropdown.
  - `DoorEntity` -> `DoorWindowEntity`, `DoorSheet` -> `DoorWindowSheet`, `SheetNames.Doors` ("Doors") -> `SheetNames.DoorsWindows` ("Doors & Windows"), matching the "Appliances & Electronics" naming convention already used in this domain.
- Adds demo-data generation to `RaptorSheets.Home` (`SetupDemo`/`PopulateDemoData`/`GenerateDemoData`), which didn't exist at all before - unlike Stock/Gig/Job. Generates a small, curated sample household (rooms, contacts, appliances, projects, maintenance log entries, doors/windows, paints, power outlets, and property Stats including Roof Type/Roof Installed) rather than large random volume, since the goal is a clean example to look at and edit. Every Home sheet is user-entered (none formula-derived), so all nine get written in one batched call.

## Test plan
- [x] `dotnet build` on the full solution - 0 warnings, 0 errors
- [x] `dotnet test` on `RaptorSheets.Home.Tests` - 37/37 passed, run live against the real test spreadsheet (delete/recreate fixture + new `SetupDemo_CreatesSheetsAndPopulatesData` test)
- [x] `HeaderContrastTests` confirms the renamed sheet ("Doors & Windows") still has correct header contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)