### PR TITLE
Retry transient API failures and ship XML docs in packages (#60, #63)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,45 @@
 <Project>
+  <PropertyGroup>
+    <!--
+      Ship the XML documentation file with the packages. The codebase already carries substantial
+      doc comments (GoogleSheetManagerBase, SheetEntityBase, SchemaValidationResult, and others);
+      without this they never reach consumers' IntelliSense.
+
+      The suppressed warnings below are all "documentation is incomplete" findings - a missing
+      comment, an unresolved cref, an undocumented parameter. They degrade the docs but still ship
+      them. CS1591 alone accounts for ~800 in Core. These are deferred to their own cleanup pass
+      rather than blocking this.
+
+      CS1570 (badly formed XML) is deliberately NOT suppressed. That one is different in kind: the
+      compiler drops the entire member from the generated .xml, so the affected type ships with no
+      documentation at all. Leaving it as a live warning means a malformed comment gets caught at
+      build time instead of silently disappearing from consumers' IntelliSense.
+    -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591;CS1573;CS1572;CS1574;CS1711;CS0419;CS1587</NoWarn>
+
+    <!-- Same inputs produce the same outputs, so package contents are byte-for-byte reproducible. -->
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <!--
+      CI-only source linking: embeds the repository URL and commit in the package so debuggers can
+      fetch the exact source a binary was built from and step into it. Restricted to CI because
+      ContinuousIntegrationBuild normalizes local paths, which is wrong for local debug builds.
+      .NET 8's SDK includes SourceLink, so no package reference is needed here.
+    -->
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Publish symbols alongside the package so stack traces from consumers are resolvable. -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
   <!--
     Runs the same C# analyzer engine that powers SonarCloud's CI checks (csharpsquid) locally,
     at build time and in the IDE, so findings like naming conventions and Cognitive Complexity

--- a/RaptorSheets.Core.Tests/Unit/Models/GoogleRetryOptionsTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Models/GoogleRetryOptionsTests.cs
@@ -1,0 +1,84 @@
+using RaptorSheets.Core.Models;
+using Xunit;
+
+namespace RaptorSheets.Core.Tests.Unit.Models;
+
+public class GoogleRetryOptionsTests
+{
+    [Fact]
+    public void Default_ShouldEnableRetriesWithinTheUnderlyingClientLimits()
+    {
+        var options = GoogleRetryOptions.Default;
+
+        Assert.True(options.Enabled);
+        Assert.InRange(options.MaxRetries, 1, GoogleRetryOptions.MaximumRetryCount);
+        Assert.InRange(options.BackOffDelta, TimeSpan.FromTicks(1), GoogleRetryOptions.MaximumBackOffDelta);
+    }
+
+    [Fact]
+    public void Default_TotalWaitShouldStayWellInsideACommonThirtySecondRequestBudget()
+    {
+        var options = GoogleRetryOptions.Default;
+
+        // Worst case is every retry capped at MaxDelay; even that has to leave room for the
+        // requests themselves inside a 30s gateway timeout.
+        var worstCaseWait = options.MaxDelay * options.MaxRetries;
+
+        Assert.True(worstCaseWait < TimeSpan.FromSeconds(30),
+            $"Worst-case retry wait of {worstCaseWait.TotalSeconds}s would consume a 30s request budget.");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(GoogleRetryOptions.MaximumRetryCount)]
+    public void MaxRetries_ShouldAcceptValuesInRange(int retries)
+    {
+        var options = new GoogleRetryOptions { MaxRetries = retries };
+
+        Assert.Equal(retries, options.MaxRetries);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(GoogleRetryOptions.MaximumRetryCount + 1)]
+    public void MaxRetries_ShouldRejectValuesOutOfRange(int retries)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new GoogleRetryOptions { MaxRetries = retries });
+    }
+
+    [Fact]
+    public void BackOffDelta_ShouldAcceptTheUnderlyingClientMaximum()
+    {
+        var options = new GoogleRetryOptions { BackOffDelta = GoogleRetryOptions.MaximumBackOffDelta };
+
+        Assert.Equal(GoogleRetryOptions.MaximumBackOffDelta, options.BackOffDelta);
+    }
+
+    [Fact]
+    public void BackOffDelta_ShouldRejectValuesAboveTheUnderlyingClientMaximum()
+    {
+        // The Google client rejects a delta above one second outright, so catching it here gives a
+        // clearer error than letting the client throw from inside service construction.
+        var tooLarge = GoogleRetryOptions.MaximumBackOffDelta + TimeSpan.FromMilliseconds(1);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new GoogleRetryOptions { BackOffDelta = tooLarge });
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void BackOffDelta_ShouldRejectNonPositiveValues(int seconds)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new GoogleRetryOptions { BackOffDelta = TimeSpan.FromSeconds(seconds) });
+    }
+
+    [Fact]
+    public void Disabled_ShouldBeExpressibleForCallersDoingTheirOwnOrchestration()
+    {
+        var options = new GoogleRetryOptions { Enabled = false };
+
+        Assert.False(options.Enabled);
+    }
+}

--- a/RaptorSheets.Core/Constants/GoogleFormulas.cs
+++ b/RaptorSheets.Core/Constants/GoogleFormulas.cs
@@ -34,7 +34,8 @@ public static class GoogleFormulas
     public const string ArrayLiteralUniqueCombined = "={\"{header}\";SORT(UNIQUE({{range1};{range2}}))}";
 
     /// <summary>
-    /// Simple array literal for unique values with combined ranges (filtered): ="{header}";SORT(UNIQUE(IFERROR(FILTER({range1};{range2}},{range1};{range2}<>""))))
+    /// Simple array literal for unique values with combined ranges (filtered):
+    /// <![CDATA[ ="{header}";SORT(UNIQUE(IFERROR(FILTER({range1};{range2}},{range1};{range2}<>"")))) ]]>
     /// Placeholders: {header}, {range1}, {range2}
     /// Used when combining multiple source ranges for unique values, excluding empty values
     /// This is the recommended version for most use cases to avoid blank entries
@@ -43,7 +44,8 @@ public static class GoogleFormulas
     public const string ArrayLiteralUniqueCombinedFiltered = "={\"{header}\";SORT(UNIQUE(IFERROR(FILTER({{range1};{range2}},{{range1};{range2}}<>\"\"))))}";
 
     /// <summary>
-    /// Simple array literal for unique filtered values: ="{header}";SORT(UNIQUE(IFERROR(FILTER({sourceRange}, {sourceRange}<>""))))
+    /// Simple array literal for unique filtered values:
+    /// <![CDATA[ ="{header}";SORT(UNIQUE(IFERROR(FILTER({sourceRange}, {sourceRange}<>"")))) ]]>
     /// Placeholders: {header}, {sourceRange}
     /// More efficient than ArrayFormulaBase for filtered unique values
     /// Sorted alphabetically/numerically
@@ -51,7 +53,8 @@ public static class GoogleFormulas
     public const string ArrayLiteralUniqueFilteredSorted = "={\"{header}\";SORT(UNIQUE(IFERROR(FILTER({sourceRange}, {sourceRange}<>\"\"))))}";
 
     /// <summary>
-    /// Simple array literal for unique filtered values: ="{header}";UNIQUE(IFERROR(FILTER({sourceRange}, {sourceRange}<>"")))
+    /// Simple array literal for unique filtered values:
+    /// <![CDATA[ ="{header}";UNIQUE(IFERROR(FILTER({sourceRange}, {sourceRange}<>""))) ]]>
     /// Placeholders: {header}, {sourceRange}
     /// Preserves source order - useful for chronological data like weeks, months
     /// This is the default - use ArrayLiteralUniqueFilteredSorted for alphabetical sorting
@@ -65,7 +68,8 @@ public static class GoogleFormulas
     public const string ArrayFormulaUnique = "=ARRAYFORMULA(IFS(ROW({keyRange})=1,\"{header}\",ISBLANK({keyRange}), \"\", true, SORT(UNIQUE({sourceRange}))))";
 
     /// <summary>
-    /// ARRAYFORMULA for unique filtered values: =ARRAYFORMULA(IFS(ROW({keyRange})=1,"{header}",ISBLANK({keyRange}), "", true, SORT(UNIQUE(IFERROR(FILTER({sourceRange}, {sourceRange}<>"")), 1)))
+    /// ARRAYFORMULA for unique filtered values:
+    /// <![CDATA[ =ARRAYFORMULA(IFS(ROW({keyRange})=1,"{header}",ISBLANK({keyRange}), "", true, SORT(UNIQUE(IFERROR(FILTER({sourceRange}, {sourceRange}<>"")), 1))) ]]>
     /// Placeholders: {keyRange}, {header}, {sourceRange}
     /// </summary>
     public const string ArrayFormulaUniqueFiltered = "=ARRAYFORMULA(IFS(ROW({keyRange})=1,\"{header}\",ISBLANK({keyRange}), \"\", true, SORT(UNIQUE(IFERROR(FILTER({sourceRange}, {sourceRange}<>\"\")), 1))))";
@@ -139,13 +143,15 @@ public static class GoogleFormulas
     public const string SplitStringByIndex = "IFERROR(INDEX(SPLIT({sourceRange}, \"{delimiter}\"), 0, {index}), 0)";
 
     /// <summary>
-    /// Week number with year: WEEKNUM({dateRange},2)&"-"&YEAR({dateRange})
+    /// Week number with year:
+    /// <![CDATA[ WEEKNUM({dateRange},2)&"-"&YEAR({dateRange}) ]]>
     /// Placeholders: {dateRange}
     /// </summary>
     public const string WeekNumberWithYear = "WEEKNUM({dateRange},2)&\"-\"&YEAR({dateRange})";
 
     /// <summary>
-    /// Month number with year: MONTH({dateRange})&"-"&YEAR({dateRange})
+    /// Month number with year:
+    /// <![CDATA[ MONTH({dateRange})&"-"&YEAR({dateRange}) ]]>
     /// Placeholders: {dateRange}
     /// </summary>
     public const string MonthNumberWithYear = "MONTH({dateRange})&\"-\"&YEAR({dateRange})";
@@ -164,7 +170,8 @@ public static class GoogleFormulas
 
     /// <summary>
     /// Complex rolling average for time series analysis using DAVERAGE with transpose matrix.
-    /// Formula: DAVERAGE(transpose({{totalRange},TRANSPOSE(if(ROW({totalRange}) <= TRANSPOSE(ROW({totalRange})),{totalRange},))}),sequence(rows({totalRange}),1),{if(,,);if(,,)})
+    /// Formula:
+    /// <![CDATA[ DAVERAGE(transpose({{totalRange},TRANSPOSE(if(ROW({totalRange}) <= TRANSPOSE(ROW({totalRange})),{totalRange},))}),sequence(rows({totalRange}),1),{if(,,);if(,,)}) ]]>
     /// Creates a cumulative average by building a growing dataset for each row; the DAVERAGE
     /// function with empty criteria averages all rows up to the current position.
     /// Placeholders: {totalRange}

--- a/RaptorSheets.Core/Extensions/ListExtensions.cs
+++ b/RaptorSheets.Core/Extensions/ListExtensions.cs
@@ -46,7 +46,6 @@ public static class ListExtensions
     }
 
     /// <summary>
-    /// <summary>
     /// Keep the first <paramref name="leadingCount"/> existing headers and pad with
     /// empty placeholders so the final header count equals the original count
     /// observed before modification. Useful when you want to preserve the

--- a/RaptorSheets.Core/Helpers/GoogleServiceInitializerHelper.cs
+++ b/RaptorSheets.Core/Helpers/GoogleServiceInitializerHelper.cs
@@ -1,0 +1,63 @@
+using Google.Apis.Http;
+using Google.Apis.Services;
+using Google.Apis.Util;
+using RaptorSheets.Core.Constants;
+using RaptorSheets.Core.Models;
+using System.Diagnostics.CodeAnalysis;
+
+namespace RaptorSheets.Core.Helpers;
+
+/// <summary>
+/// Builds the Google client service initializer shared by <see cref="Wrappers.SheetServiceWrapper"/>
+/// and <see cref="Wrappers.DriveServiceWrapper"/>, including transient-failure retry.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public static class GoogleServiceInitializerHelper
+{
+    private const int TooManyRequests = 429;
+
+    /// <summary>
+    /// Creates an initializer with the app name and the built-in exponential backoff policy applied.
+    /// The built-in policy covers 503s and transport exceptions only - rate limiting (429) needs
+    /// <see cref="ApplyRateLimitBackOff"/> on the constructed service as well.
+    /// </summary>
+    public static BaseClientService.Initializer CreateInitializer(
+        IConfigurableHttpClientInitializer httpInitializer,
+        GoogleRetryOptions? retryOptions = null)
+    {
+        var options = retryOptions ?? GoogleRetryOptions.Default;
+
+        return new BaseClientService.Initializer
+        {
+            HttpClientInitializer = httpInitializer,
+            ApplicationName = GoogleConfig.AppName,
+            DefaultExponentialBackOffPolicy = options.Enabled
+                ? ExponentialBackOffPolicy.Exception | ExponentialBackOffPolicy.UnsuccessfulResponse503
+                : ExponentialBackOffPolicy.None
+        };
+    }
+
+    /// <summary>
+    /// Registers backoff for HTTP 429 responses, which the built-in policy does not cover. The Sheets
+    /// API enforces low per-minute quotas, so 429 is the transient failure callers actually hit;
+    /// without this, a burst of concurrent work fails hard instead of pausing and succeeding.
+    /// </summary>
+    public static void ApplyRateLimitBackOff(BaseClientService service, GoogleRetryOptions? retryOptions = null)
+    {
+        var options = retryOptions ?? GoogleRetryOptions.Default;
+
+        if (!options.Enabled || options.MaxRetries == 0)
+        {
+            return;
+        }
+
+        var backOff = new ExponentialBackOff(options.BackOffDelta, options.MaxRetries);
+        var handler = new BackOffHandler(new BackOffHandler.Initializer(backOff)
+        {
+            MaxTimeSpan = options.MaxDelay,
+            HandleUnsuccessfulResponseFunc = response => (int)response.StatusCode == TooManyRequests
+        });
+
+        service.HttpClient.MessageHandler.AddUnsuccessfulResponseHandler(handler);
+    }
+}

--- a/RaptorSheets.Core/Mappers/PropertyEntityMapper.cs
+++ b/RaptorSheets.Core/Mappers/PropertyEntityMapper.cs
@@ -12,6 +12,7 @@ public static class PropertyEntityMapper
     /// Additional file metadata can be placed into the returned entity's <see cref="PropertyEntity.Attributes"/> dictionary.
     /// Example usage:
     /// <code>
+    /// <![CDATA[
     /// var entity = new PropertyEntity
     /// {
     ///     Id = file.Id,
@@ -22,6 +23,7 @@ public static class PropertyEntityMapper
     ///         { "CreatedTime", file.CreatedTimeRaw }
     ///     }
     /// };
+    /// ]]>
     /// </code>
     /// </remarks>
     public static PropertyEntity MapFromDriveFile(File? file)

--- a/RaptorSheets.Core/Models/GoogleRetryOptions.cs
+++ b/RaptorSheets.Core/Models/GoogleRetryOptions.cs
@@ -1,0 +1,84 @@
+namespace RaptorSheets.Core.Models;
+
+/// <summary>
+/// Controls automatic retry of transient Google API failures (rate limiting, 503s, and transport
+/// exceptions). Defaults are tuned for callers running behind a request timeout - see
+/// <see cref="MaxDelay"/> - so a burst of retries can't consume the whole budget.
+/// </summary>
+public class GoogleRetryOptions
+{
+    /// <summary>
+    /// Largest value the underlying Google client accepts for <see cref="BackOffDelta"/>. The client
+    /// treats the delta as a small base unit and grows it exponentially, so it rejects anything above
+    /// one second outright.
+    /// </summary>
+    public static readonly TimeSpan MaximumBackOffDelta = TimeSpan.FromSeconds(1);
+
+    /// <summary>Largest value the underlying Google client accepts for <see cref="MaxRetries"/>.</summary>
+    public const int MaximumRetryCount = 20;
+
+    /// <summary>
+    /// Shared default instance: retries enabled, 3 attempts, a 1 second backoff delta, and an 8
+    /// second ceiling on any single wait.
+    /// </summary>
+    public static GoogleRetryOptions Default { get; } = new();
+
+    /// <summary>
+    /// Whether transient failures are retried at all. Set false when the caller does its own
+    /// orchestration and wants failures surfaced immediately.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+
+    private readonly int _maxRetries = 3;
+
+    /// <summary>
+    /// How many times a transient failure is retried before the error is surfaced. Kept small
+    /// deliberately: past a few attempts the caller is better served by being told than by waiting.
+    /// </summary>
+    public int MaxRetries
+    {
+        get => _maxRetries;
+        init
+        {
+            if (value < 0 || value > MaximumRetryCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(MaxRetries), value,
+                    $"Retry count must be between 0 and {MaximumRetryCount}.");
+            }
+
+            _maxRetries = value;
+        }
+    }
+
+    private readonly TimeSpan _backOffDelta = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Base unit of the exponential curve, not the literal first delay. The client waits roughly
+    /// <c>delta * (2^attempt - 1)</c> with jitter applied, so at the default of one second the actual
+    /// waits land near 1.5s, 2.9s, and 4.3s. Must be greater than zero and no more than
+    /// <see cref="MaximumBackOffDelta"/>; the default is that maximum, since spacing retries out
+    /// generously is what actually lets a per-minute quota recover.
+    /// </summary>
+    public TimeSpan BackOffDelta
+    {
+        get => _backOffDelta;
+        init
+        {
+            if (value <= TimeSpan.Zero || value > MaximumBackOffDelta)
+            {
+                throw new ArgumentOutOfRangeException(nameof(BackOffDelta), value,
+                    $"Backoff delta must be greater than zero and no more than {MaximumBackOffDelta.TotalSeconds} second(s).");
+            }
+
+            _backOffDelta = value;
+        }
+    }
+
+    /// <summary>
+    /// Ceiling on any single wait. Once the exponential curve would exceed this, retrying stops and
+    /// the error is surfaced. This is what keeps a retry storm from blowing a caller's request
+    /// budget - with the defaults, total time spent waiting stays under about 9 seconds, which fits
+    /// inside a 30 second gateway timeout with room for the requests themselves.
+    /// </summary>
+    public TimeSpan MaxDelay { get; init; } = TimeSpan.FromSeconds(8);
+}

--- a/RaptorSheets.Core/Services/GoogleDriveService.cs
+++ b/RaptorSheets.Core/Services/GoogleDriveService.cs
@@ -1,5 +1,6 @@
 ﻿using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Mappers;
+using RaptorSheets.Core.Models;
 using RaptorSheets.Core.Wrappers;
 using System.Diagnostics.CodeAnalysis;
 
@@ -16,9 +17,9 @@ public class GoogleDriveService : IGoogleDriveService
 {
     private readonly DriveServiceWrapper _driveService;
 
-    public GoogleDriveService(string accessToken)
+    public GoogleDriveService(string accessToken, GoogleRetryOptions? retryOptions = null)
     {
-        _driveService = new DriveServiceWrapper(accessToken);
+        _driveService = new DriveServiceWrapper(accessToken, retryOptions);
     }
 
     public async Task<PropertyEntity> CreateSpreadsheet(string name)

--- a/RaptorSheets.Core/Services/GoogleSheetService.cs
+++ b/RaptorSheets.Core/Services/GoogleSheetService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using RaptorSheets.Core.Constants;
 using RaptorSheets.Core.Helpers;
+using RaptorSheets.Core.Models;
 using RaptorSheets.Core.Wrappers;
 using System.Diagnostics.CodeAnalysis;
 
@@ -28,15 +29,15 @@ public class GoogleSheetService : IGoogleSheetService
     private readonly string _range = GoogleConfig.Range;
     private readonly ILogger _logger;
 
-    public GoogleSheetService(string accessToken, string spreadsheetId, ILogger? logger = null)
+    public GoogleSheetService(string accessToken, string spreadsheetId, ILogger? logger = null, GoogleRetryOptions? retryOptions = null)
     {
-        _sheetService = new SheetServiceWrapper(accessToken, spreadsheetId);
+        _sheetService = new SheetServiceWrapper(accessToken, spreadsheetId, retryOptions);
         _logger = logger ?? NullLogger.Instance;
     }
 
-    public GoogleSheetService(Dictionary<string, string> parameters, string spreadsheetId, ILogger? logger = null)
+    public GoogleSheetService(Dictionary<string, string> parameters, string spreadsheetId, ILogger? logger = null, GoogleRetryOptions? retryOptions = null)
     {
-        _sheetService = new SheetServiceWrapper(parameters, spreadsheetId);
+        _sheetService = new SheetServiceWrapper(parameters, spreadsheetId, retryOptions);
         _logger = logger ?? NullLogger.Instance;
     }
 

--- a/RaptorSheets.Core/Wrappers/DriveServiceWrapper.cs
+++ b/RaptorSheets.Core/Wrappers/DriveServiceWrapper.cs
@@ -1,6 +1,7 @@
 ﻿using Google.Apis.Auth.OAuth2;
 using Google.Apis.Drive.v3;
-using RaptorSheets.Core.Constants;
+using RaptorSheets.Core.Helpers;
+using RaptorSheets.Core.Models;
 using System.Diagnostics.CodeAnalysis;
 using File = Google.Apis.Drive.v3.Data.File;
 
@@ -16,9 +17,11 @@ public interface IDriveServiceWrapper
 public class DriveServiceWrapper : DriveService, IDriveServiceWrapper
 {
     private DriveService _driveService = new();
+    private readonly GoogleRetryOptions _retryOptions;
 
-    public DriveServiceWrapper(string accessToken)
+    public DriveServiceWrapper(string accessToken, GoogleRetryOptions? retryOptions = null)
     {
+        _retryOptions = retryOptions ?? GoogleRetryOptions.Default;
         var credential = GoogleCredential.FromAccessToken(accessToken.Trim());
 
         InitializeService(credential);
@@ -26,11 +29,10 @@ public class DriveServiceWrapper : DriveService, IDriveServiceWrapper
 
     private void InitializeService(GoogleCredential credential)
     {
-        _driveService = new DriveService(new Initializer()
-        {
-            HttpClientInitializer = credential,
-            ApplicationName = GoogleConfig.AppName
-        });
+        _driveService = new DriveService(
+            GoogleServiceInitializerHelper.CreateInitializer(credential, _retryOptions));
+
+        GoogleServiceInitializerHelper.ApplyRateLimitBackOff(_driveService, _retryOptions);
     }
 
     public async Task<File> CreateSpreadsheet(string name)

--- a/RaptorSheets.Core/Wrappers/SheetServiceWrapper.cs
+++ b/RaptorSheets.Core/Wrappers/SheetServiceWrapper.cs
@@ -1,7 +1,8 @@
 ﻿using Google.Apis.Auth.OAuth2;
 using Google.Apis.Sheets.v4;
 using Google.Apis.Sheets.v4.Data;
-using RaptorSheets.Core.Constants;
+using RaptorSheets.Core.Helpers;
+using RaptorSheets.Core.Models;
 using System.Diagnostics.CodeAnalysis;
 using static Google.Apis.Sheets.v4.SpreadsheetsResource.ValuesResource;
 
@@ -25,18 +26,21 @@ public class SheetServiceWrapper : SheetsService, ISheetServiceWrapper
 {
     private SheetsService _sheetsService = new();
     private readonly string _spreadsheetId;
+    private readonly GoogleRetryOptions _retryOptions;
 
-    public SheetServiceWrapper(string accessToken, string spreadsheetId)
+    public SheetServiceWrapper(string accessToken, string spreadsheetId, GoogleRetryOptions? retryOptions = null)
     {
         _spreadsheetId = spreadsheetId;
+        _retryOptions = retryOptions ?? GoogleRetryOptions.Default;
         var credential = GoogleCredential.FromAccessToken(accessToken.Trim());
 
         InitializeService(credential);
     }
 
-    public SheetServiceWrapper(Dictionary<string, string> parameters, string spreadsheetId)
+    public SheetServiceWrapper(Dictionary<string, string> parameters, string spreadsheetId, GoogleRetryOptions? retryOptions = null)
     {
         _spreadsheetId = spreadsheetId;
+        _retryOptions = retryOptions ?? GoogleRetryOptions.Default;
         // Resolve credential parameters with tolerant key lookup to accept either
         // camelCase (privateKey, privateKeyId, clientEmail, clientId) or
         // snake_case (private_key, private_key_id, client_email, client_id) names.
@@ -113,11 +117,10 @@ public class SheetServiceWrapper : SheetsService, ISheetServiceWrapper
 
     private void InitializeService(Google.Apis.Http.IConfigurableHttpClientInitializer httpInitializer)
     {
-        _sheetsService = new SheetsService(new Initializer()
-        {
-            HttpClientInitializer = httpInitializer,
-            ApplicationName = GoogleConfig.AppName
-        });
+        _sheetsService = new SheetsService(
+            GoogleServiceInitializerHelper.CreateInitializer(httpInitializer, _retryOptions));
+
+        GoogleServiceInitializerHelper.ApplyRateLimitBackOff(_sheetsService, _retryOptions);
     }
 
     public async Task<AppendValuesResponse> AppendValues(string range, IList<IList<object>> values)

--- a/RaptorSheets.Gig/Constants/GigFormulas.cs
+++ b/RaptorSheets.Gig/Constants/GigFormulas.cs
@@ -82,13 +82,15 @@ public static class GigFormulas
     #region Shift-Specific Business Logic
 
     /// <summary>
-    /// Shift key generation: IFS(ROW({keyRange})=1,"{header}",ISBLANK({serviceRange}), "",true,IF(ISBLANK({numberRange}), {dateRange} & "-0-" & {serviceRange}, {dateRange} & "-" & {numberRange} & "-" & {serviceRange}))
+    /// Shift key generation:
+    /// <![CDATA[ IFS(ROW({keyRange})=1,"{header}",ISBLANK({serviceRange}), "",true,IF(ISBLANK({numberRange}), {dateRange} & "-0-" & {serviceRange}, {dateRange} & "-" & {numberRange} & "-" & {serviceRange})) ]]>
     /// Placeholders: {keyRange}, {header}, {serviceRange}, {numberRange}, {dateRange}
     /// </summary>
     public const string ShiftKeyGeneration = "IFS(ROW({keyRange})=1,\"{header}\",ISBLANK({serviceRange}), \"\",true,IF(ISBLANK({numberRange}), {dateRange} & \"-0-\" & {serviceRange}, {dateRange} & \"-\" & {numberRange} & \"-\" & {serviceRange}))";
 
     /// <summary>
-    /// Trip key generation with exclude: IF({excludeRange},{dateRange} & "-X-" & {serviceRange},IF(ISBLANK({numberRange}), {dateRange} & "-0-" & {serviceRange}, {dateRange} & "-" & {numberRange} & "-" & {serviceRange}))
+    /// Trip key generation with exclude:
+    /// <![CDATA[ IF({excludeRange},{dateRange} & "-X-" & {serviceRange},IF(ISBLANK({numberRange}), {dateRange} & "-0-" & {serviceRange}, {dateRange} & "-" & {numberRange} & "-" & {serviceRange})) ]]>
     /// Placeholders: {excludeRange}, {dateRange}, {serviceRange}, {numberRange}
     /// </summary>
     public const string TripKeyGeneration = "IF({excludeRange},{dateRange} & \"-X-\" & {serviceRange},IF(ISBLANK({numberRange}), {dateRange} & \"-0-\" & {serviceRange}, {dateRange} & \"-\" & {numberRange} & \"-\" & {serviceRange}))";


### PR DESCRIPTION
Two quick wins from the improvement backlog. Both touch only Core and the build props.

Closes #60
Closes #63

## #60 — Exponential backoff on the Google clients

The Sheets and Drive clients had no retry policy, so a 429 from the API's low per-minute quota failed hard. This is a large part of why integration tests are flaky when several domains hit the API at once.

- Enables the client's built-in backoff for 503s and transport exceptions.
- Registers an explicit handler for **429**, which the built-in policy does *not* cover — this is the failure callers actually hit.
- `GoogleRetryOptions` exposes retry count, backoff delta, per-wait ceiling, and an opt-out, threaded as an optional argument through the wrappers and services. Existing call sites are unchanged.

Two things worth reviewer attention:

**The delta is a base unit, not a first delay.** The client waits roughly `delta * (2^attempt - 1)` with jitter. I confirmed the limits empirically rather than from docs (they're undocumented): **delta is capped at 1 second** and **retries at 20**. `GoogleRetryOptions` validates both, so a bad value throws with a clear message instead of an opaque `ArgumentOutOfRangeException` from inside service construction. My first attempt used a 2 second delta and broke 10 tests exactly this way.

**Defaults are sized against the 30s budget.** At the defaults the actual waits land near 1.5s / 2.9s / 4.3s — under ~9 seconds total, leaving room for the requests themselves inside a gateway timeout.

## #63 — Ship XML docs, deterministic and SourceLink builds

No packable project generated a documentation file, so the doc comments already in the codebase never reached consumers' IntelliSense.

Enables `GenerateDocumentationFile`, `Deterministic`, symbol packages (`snupkg`), and CI-only source linking.

**This surfaced a real defect.** Turning docs on revealed **11 members being dropped from the generated `.xml` entirely** — formula constants whose doc comments contain bare `&` and `<>` from the Sheets formula text, which is invalid XML. The compiler quietly replaces them with `<!-- Badly formed XML comment ignored -->`, so those members would have shipped with no documentation regardless. Fixed via CDATA, plus a duplicated `<summary>` tag and an unescaped generic in a code sample.

**Warning policy is deliberate.** CS1570 (badly formed XML) is left *unsuppressed*, since that's the one that drops members — a future malformed comment should fail loudly. The "documentation is incomplete" family (CS1591 and friends, ~800 in Core alone) is suppressed for now and left to its own cleanup pass.

## Verification

- Full solution builds clean — only one pre-existing unrelated warning remains.
- **1,612 unit tests pass** across Core, Gig, Stock, Job, and Home. Integration tests were not run (live API quota).
- `dotnet pack` confirmed: package now contains `lib/net8.0/RaptorSheets.Core.xml` and produces a `.snupkg`.

## Not included

No behavior change to reads or writes, no public signature removed. Full configurability of retry from a host's configuration arrives with the DI work (#62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
