### PR TITLE
Fail fast on unusable credentials, drop wrapper self-inheritance (#66)

### DIFF
--- a/RaptorSheets.Core.Tests/RaptorSheets.Core.Tests.csproj
+++ b/RaptorSheets.Core.Tests/RaptorSheets.Core.Tests.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\RaptorSheets.Core\RaptorSheets.Core.csproj" />
+    <ProjectReference Include="..\RaptorSheets.Test\RaptorSheets.Test.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/RaptorSheets.Core.Tests/Unit/Managers/GoogleSheetManagerBaseTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Managers/GoogleSheetManagerBaseTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using RaptorSheets.Core.Managers;
 using RaptorSheets.Core.Services;
+using RaptorSheets.Test.Common.Helpers;
 using Xunit;
 
 namespace RaptorSheets.Core.Tests.Unit.Managers;
@@ -71,19 +72,21 @@ public class GoogleSheetManagerBaseTests
     [Fact]
     public void Constructor_WithParametersDictionaryAndSpreadsheetId_ShouldInitializeWithoutThrowing()
     {
-        // Minimal fake service-account parameters; we only verify construction, not a live call
-        var parameters = new Dictionary<string, string>
-        {
-            { "type", "service_account" },
-            { "privateKeyId", "fake-key-id" },
-            { "privateKey", "-----BEGIN PRIVATE KEY-----\\nMIIB...fake...\\n-----END PRIVATE KEY-----\\n" },
-            { "clientEmail", "test@example.com" },
-            { "clientId", "123" }
-        };
+        // Throwaway service-account parameters; we only verify construction, not a live call
+        var parameters = GoogleCredentialHelpers.CreateServiceAccountParameters();
 
         var manager = new TestGoogleSheetManager(parameters, "test-spreadsheet-id");
 
         Assert.NotNull(manager.ServiceForTest);
         Assert.NotNull(manager.LoggerForTest);
+    }
+
+    [Fact]
+    public void Constructor_WithMalformedPrivateKey_ShouldThrowRatherThanDeferToFirstApiCall()
+    {
+        var parameters = GoogleCredentialHelpers.CreateMalformedServiceAccountParameters();
+
+        Assert.Throws<ArgumentException>(
+            () => new TestGoogleSheetManager(parameters, "test-spreadsheet-id"));
     }
 }

--- a/RaptorSheets.Core.Tests/Wrappers/SheetServiceWrapperTests.cs
+++ b/RaptorSheets.Core.Tests/Wrappers/SheetServiceWrapperTests.cs
@@ -1,3 +1,4 @@
+using RaptorSheets.Test.Common.Helpers;
 using RaptorSheets.Core.Wrappers;
 using Xunit;
 
@@ -22,16 +23,8 @@ public class SheetServiceWrapperTests
     [Fact]
     public void Wrapper_CanBeConstructed_WithServiceAccountParameters()
     {
-        // Arrange - minimal fake parameters; we only verify construction, not a live call
-        var parameters = new Dictionary<string, string>
-        {
-            { "type", "service_account" },
-            { "privateKeyId", "fake-key-id" },
-            { "privateKey", "-----BEGIN PRIVATE KEY-----\\nMIIB...fake...\\n-----END PRIVATE KEY-----\\n" },
-            { "clientEmail", "test@example.com" },
-            { "clientId", "123" }
-        };
-
+        // Arrange - a real (throwaway) key, since the credential layer actually parses it
+        var parameters = GoogleCredentialHelpers.CreateServiceAccountParameters();
         var spreadsheetId = "spreadsheet-id";
 
         // Act
@@ -39,5 +32,29 @@ public class SheetServiceWrapperTests
 
         // Assert
         Assert.NotNull(wrapper);
+    }
+
+    [Fact]
+    public void Wrapper_ShouldThrow_WhenPrivateKeyIsMalformed()
+    {
+        // Unusable key material fails every subsequent API call, so construction is where the caller
+        // should hear about it - not a confusing 401 on the first request.
+        var parameters = GoogleCredentialHelpers.CreateMalformedServiceAccountParameters();
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new SheetServiceWrapper(parameters, "spreadsheet-id"));
+
+        Assert.Contains("private key", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("privateKey")]
+    [InlineData("clientEmail")]
+    public void Wrapper_ShouldThrow_WhenRequiredParameterIsMissing(string missingKey)
+    {
+        var parameters = GoogleCredentialHelpers.CreateServiceAccountParameters();
+        parameters.Remove(missingKey);
+
+        Assert.Throws<ArgumentException>(() => new SheetServiceWrapper(parameters, "spreadsheet-id"));
     }
 }

--- a/RaptorSheets.Core/Services/GoogleDriveService.cs
+++ b/RaptorSheets.Core/Services/GoogleDriveService.cs
@@ -15,7 +15,7 @@ public interface IGoogleDriveService
 [ExcludeFromCodeCoverage]
 public class GoogleDriveService : IGoogleDriveService
 {
-    private readonly DriveServiceWrapper _driveService;
+    private readonly IDriveServiceWrapper _driveService;
 
     public GoogleDriveService(string accessToken, GoogleRetryOptions? retryOptions = null)
     {

--- a/RaptorSheets.Core/Services/GoogleSheetService.cs
+++ b/RaptorSheets.Core/Services/GoogleSheetService.cs
@@ -25,7 +25,7 @@ public interface IGoogleSheetService
 [ExcludeFromCodeCoverage]
 public class GoogleSheetService : IGoogleSheetService
 {
-    private readonly SheetServiceWrapper _sheetService;
+    private readonly ISheetServiceWrapper _sheetService;
     private readonly string _range = GoogleConfig.Range;
     private readonly ILogger _logger;
 

--- a/RaptorSheets.Core/Wrappers/DriveServiceWrapper.cs
+++ b/RaptorSheets.Core/Wrappers/DriveServiceWrapper.cs
@@ -14,25 +14,25 @@ public interface IDriveServiceWrapper
 }
 
 [ExcludeFromCodeCoverage]
-public class DriveServiceWrapper : DriveService, IDriveServiceWrapper
+public class DriveServiceWrapper : IDriveServiceWrapper
 {
-    private DriveService _driveService = new();
-    private readonly GoogleRetryOptions _retryOptions;
+    private readonly DriveService _driveService;
 
     public DriveServiceWrapper(string accessToken, GoogleRetryOptions? retryOptions = null)
     {
-        _retryOptions = retryOptions ?? GoogleRetryOptions.Default;
         var credential = GoogleCredential.FromAccessToken(accessToken.Trim());
 
-        InitializeService(credential);
+        _driveService = CreateService(credential, retryOptions);
     }
 
-    private void InitializeService(GoogleCredential credential)
+    private static DriveService CreateService(GoogleCredential credential, GoogleRetryOptions? retryOptions)
     {
-        _driveService = new DriveService(
-            GoogleServiceInitializerHelper.CreateInitializer(credential, _retryOptions));
+        var service = new DriveService(
+            GoogleServiceInitializerHelper.CreateInitializer(credential, retryOptions));
 
-        GoogleServiceInitializerHelper.ApplyRateLimitBackOff(_driveService, _retryOptions);
+        GoogleServiceInitializerHelper.ApplyRateLimitBackOff(service, retryOptions);
+
+        return service;
     }
 
     public async Task<File> CreateSpreadsheet(string name)

--- a/RaptorSheets.Core/Wrappers/SheetServiceWrapper.cs
+++ b/RaptorSheets.Core/Wrappers/SheetServiceWrapper.cs
@@ -22,25 +22,22 @@ public interface ISheetServiceWrapper
 }
 
 [ExcludeFromCodeCoverage]
-public class SheetServiceWrapper : SheetsService, ISheetServiceWrapper
+public class SheetServiceWrapper : ISheetServiceWrapper
 {
-    private SheetsService _sheetsService = new();
+    private readonly SheetsService _sheetsService;
     private readonly string _spreadsheetId;
-    private readonly GoogleRetryOptions _retryOptions;
 
     public SheetServiceWrapper(string accessToken, string spreadsheetId, GoogleRetryOptions? retryOptions = null)
     {
         _spreadsheetId = spreadsheetId;
-        _retryOptions = retryOptions ?? GoogleRetryOptions.Default;
         var credential = GoogleCredential.FromAccessToken(accessToken.Trim());
 
-        InitializeService(credential);
+        _sheetsService = CreateService(credential, retryOptions);
     }
 
     public SheetServiceWrapper(Dictionary<string, string> parameters, string spreadsheetId, GoogleRetryOptions? retryOptions = null)
     {
         _spreadsheetId = spreadsheetId;
-        _retryOptions = retryOptions ?? GoogleRetryOptions.Default;
         // Resolve credential parameters with tolerant key lookup to accept either
         // camelCase (privateKey, privateKeyId, clientEmail, clientId) or
         // snake_case (private_key, private_key_id, client_email, client_id) names.
@@ -63,26 +60,24 @@ public class SheetServiceWrapper : SheetsService, ISheetServiceWrapper
         // The private key in parameters typically contains escaped newlines; ensure proper formatting
         var privateKey = jsonCredential.PrivateKey?.Replace("\\n", "\n");
 
-        Google.Apis.Auth.OAuth2.GoogleCredential credential;
+        GoogleCredential credential;
         try
         {
             var serviceAccountCredential = new ServiceAccountCredential(initializer.FromPrivateKey(privateKey));
             // Convert to GoogleCredential for compatibility with APIs that expect it (and to be used as HttpClientInitializer)
             credential = serviceAccountCredential.ToGoogleCredential();
         }
-        catch (FormatException)
+        catch (Exception ex) when (ex is FormatException or ArgumentException)
         {
-            // Tests may supply a non-real private key (placeholder). Fall back to a harmless access-token based credential
-            // so unit tests can construct the wrapper without requiring a valid RSA private key.
-            credential = GoogleCredential.FromAccessToken("test-token");
-        }
-        catch (ArgumentException)
-        {
-            // Specific argument exceptions during FromPrivateKey indicate malformed key material.
-            credential = GoogleCredential.FromAccessToken("test-token");
+            // Fail here rather than later. Unusable key material means every subsequent API call will
+            // fail authentication, and diagnosing that from a 401 on the first request is far harder
+            // than being told at construction which credential parameter was bad.
+            throw new ArgumentException(
+                "The private key credential parameter is not a valid PEM-encoded RSA private key.",
+                nameof(parameters), ex);
         }
 
-        InitializeService(credential);
+        _sheetsService = CreateService(credential, retryOptions);
     }
 
     private static string ResolveParameter(Dictionary<string, string> parameters, params string[] candidates)
@@ -115,12 +110,16 @@ public class SheetServiceWrapper : SheetsService, ISheetServiceWrapper
         throw new ArgumentException($"Missing required parameter. Expected one of: {string.Join(", ", candidates)}", nameof(parameters));
     }
 
-    private void InitializeService(Google.Apis.Http.IConfigurableHttpClientInitializer httpInitializer)
+    private static SheetsService CreateService(
+        Google.Apis.Http.IConfigurableHttpClientInitializer httpInitializer,
+        GoogleRetryOptions? retryOptions)
     {
-        _sheetsService = new SheetsService(
-            GoogleServiceInitializerHelper.CreateInitializer(httpInitializer, _retryOptions));
+        var service = new SheetsService(
+            GoogleServiceInitializerHelper.CreateInitializer(httpInitializer, retryOptions));
 
-        GoogleServiceInitializerHelper.ApplyRateLimitBackOff(_sheetsService, _retryOptions);
+        GoogleServiceInitializerHelper.ApplyRateLimitBackOff(service, retryOptions);
+
+        return service;
     }
 
     public async Task<AppendValuesResponse> AppendValues(string range, IList<IList<object>> values)

--- a/RaptorSheets.Stock.Tests/Unit/Managers/GoogleSheetManagerTests.cs
+++ b/RaptorSheets.Stock.Tests/Unit/Managers/GoogleSheetManagerTests.cs
@@ -2,6 +2,7 @@ using Google.Apis.Sheets.v4.Data;
 using RaptorSheets.Core.Extensions;
 using RaptorSheets.Stock.Entities;
 using RaptorSheets.Stock.Managers;
+using RaptorSheets.Test.Common.Helpers;
 using Xunit;
 using SheetName = RaptorSheets.Stock.Enums.SheetName;
 
@@ -19,22 +20,24 @@ public class GoogleSheetManagerTests
     [Fact]
     public void Constructor_WithParameters_ShouldInitialize()
     {
-        // Arrange - provide all required parameters for service account authentication
-        var parameters = new Dictionary<string, string>
-        {
-            ["type"] = "service_account",
-            ["privateKeyId"] = "test-key-id",
-            ["privateKey"] = "invalid-key",
-            ["clientEmail"] = "test@example.com",
-            ["clientId"] = "123456"
-        };
+        // Arrange - all required parameters for service account authentication
+        var parameters = GoogleCredentialHelpers.CreateServiceAccountParameters();
 
-        // Act & Assert - With the new fallback behavior for invalid private keys,
-        // construction should not throw and the manager should initialize.
+        // Act & Assert
         var caughtException = Record.Exception(() => new GoogleSheetManager(parameters, "test-spreadsheet"));
         Assert.Null(caughtException);
         var manager = new GoogleSheetManager(parameters, "test-spreadsheet");
         Assert.NotNull(manager);
+    }
+
+    [Fact]
+    public void Constructor_WithMalformedPrivateKey_ShouldThrow()
+    {
+        // Unusable key material used to be swallowed and replaced with a placeholder credential,
+        // which deferred the failure to an opaque 401 on the first API call.
+        var parameters = GoogleCredentialHelpers.CreateMalformedServiceAccountParameters();
+
+        Assert.Throws<ArgumentException>(() => new GoogleSheetManager(parameters, "test-spreadsheet"));
     }
 
     [Fact]

--- a/RaptorSheets.Test/Helpers/GoogleCredentialHelpers.cs
+++ b/RaptorSheets.Test/Helpers/GoogleCredentialHelpers.cs
@@ -1,7 +1,42 @@
-﻿namespace RaptorSheets.Test.Common.Helpers;
+﻿using System.Security.Cryptography;
+
+namespace RaptorSheets.Test.Common.Helpers;
 
 public static class GoogleCredentialHelpers
 {
+    /// <summary>
+    /// Builds service-account parameters carrying a well-formed, freshly generated RSA private key.
+    /// <para>
+    /// The key is generated per call and never associated with a real Google account, so nothing here
+    /// is a secret. It has to be genuine key material rather than a placeholder string because the
+    /// credential layer parses it during construction - see
+    /// <see cref="CreateMalformedServiceAccountParameters"/> for the case where it cannot.
+    /// </para>
+    /// </summary>
+    public static Dictionary<string, string> CreateServiceAccountParameters(string? privateKeyPem = null)
+    {
+        using var rsa = RSA.Create(2048);
+
+        return new Dictionary<string, string>
+        {
+            { "type", "service_account" },
+            { "privateKeyId", "test-key-id" },
+            { "privateKey", privateKeyPem ?? rsa.ExportPkcs8PrivateKeyPem() },
+            { "clientEmail", "test@example.com" },
+            { "clientId", "123" }
+        };
+    }
+
+    /// <summary>
+    /// Builds service-account parameters whose private key cannot be parsed as PEM-encoded RSA key
+    /// material, for asserting that unusable credentials fail at construction.
+    /// </summary>
+    public static Dictionary<string, string> CreateMalformedServiceAccountParameters()
+    {
+        return CreateServiceAccountParameters(
+            "-----BEGIN PRIVATE KEY-----\\nMIIB...not-a-real-key...\\n-----END PRIVATE KEY-----\\n");
+    }
+
     public static bool IsCredentialFilled(Dictionary<string, string> credentials)
     {
         if (credentials["type"] != string.Empty && credentials["privateKeyId"] != string.Empty && credentials["privateKey"] != string.Empty && credentials["clientEmail"] != string.Empty && credentials["clientId"] != string.Empty)


### PR DESCRIPTION
Closes #66

> Supersedes #72, which GitHub auto-closed when its base branch (`feature/api-reliability-and-packaging`) was deleted on merge of #71. Same commit, rebased onto `main`.

## The credential fallback

`SheetServiceWrapper` caught `FormatException`/`ArgumentException` from malformed private key material and substituted `GoogleCredential.FromAccessToken("test-token")`. A deployment with a truncated secret or a bad newline escape therefore **constructed successfully** and failed later with an opaque 401 on the first API call. The comment said the fallback existed so unit tests could construct the wrapper with placeholder key material.

Now it throws an `ArgumentException` naming the offending credential parameter, at construction.

**The tests got better rather than just updated.** They previously passed `"MIIB...fake..."`, which never parsed — meaning the "can construct with service account parameters" test was only ever exercising the fallback path, not real credential handling. They now generate a genuine throwaway RSA key via `RSA.Create(2048).ExportPkcs8PrivateKeyPem()`, so the happy path is actually covered, plus new explicit coverage for malformed and missing credentials.

The helper lives in `RaptorSheets.Test.Common` alongside the existing credential helpers. Core.Tests didn't reference that project — it does now, which is why the csproj changed.

A Stock test also asserted the old behavior explicitly (*"With the new fallback behavior for invalid private keys, construction should not throw"*), so it's been inverted to assert the throw.

## The self-inheritance

Both wrappers derived from the type they wrap while also holding an instance of it:

```csharp
public class SheetServiceWrapper : SheetsService, ISheetServiceWrapper
{
    private SheetsService _sheetsService = new();
```

So each allocated a throwaway service on construction that `InitializeService` immediately discarded. Both now implement only their interface, with the inner service `readonly` and built by a static factory. `GoogleSheetService`/`GoogleDriveService` hold the interfaces rather than the concrete wrappers.

Nothing depended on the `SheetsService`/`DriveService` base — verified by grep; both callers only ever used interface members.

## Verification

- Solution builds clean (one pre-existing unrelated warning).
- **1,617 unit tests pass** across all five projects, up 5 from the new coverage. Integration tests not run (live API quota).

## Worth a follow-up, not done here

Removing the inheritance also removes the `IDisposable` the wrappers previously inherited, and the inner `SheetsService`/`DriveService` is not disposed. That was already true before this change — the inherited base was disposable but the *held* instance never got disposed either — so this is not a regression. These services are effectively long-lived singletons today, so I left it rather than expand scope. Happy to file it if you want it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
