### PR TITLE
Add IServiceCollection extensions for registering domain managers (#62)

### DIFF
--- a/RaptorSheets.Core.Tests/RaptorSheets.Core.Tests.csproj
+++ b/RaptorSheets.Core.Tests/RaptorSheets.Core.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/RaptorSheets.Core.Tests/Unit/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,168 @@
+using Microsoft.Extensions.DependencyInjection;
+using RaptorSheets.Core.Extensions;
+using RaptorSheets.Core.Factories;
+using RaptorSheets.Core.Services;
+using RaptorSheets.Test.Common.Helpers;
+using Xunit;
+
+namespace RaptorSheets.Core.Tests.Unit.Extensions;
+
+public class ServiceCollectionExtensionsTests
+{
+    // Stand-in for a domain manager; Core has no concrete manager of its own to register.
+    public interface ITestManager
+    {
+        IGoogleSheetService Service { get; }
+    }
+
+    private sealed class TestManager(IGoogleSheetService service) : ITestManager
+    {
+        public IGoogleSheetService Service { get; } = service;
+    }
+
+    private static IServiceCollection AddTestManager(
+        IServiceCollection services,
+        string domainName = "Test",
+        Action<Options.RaptorSheetsOptions>? configure = null)
+    {
+        return services.AddSheetManager<ITestManager>(
+            domainName,
+            (service, _) => new TestManager(service),
+            configure);
+    }
+
+    [Fact]
+    public void AddSheetManager_WithoutOptions_ShouldStillRegisterTheFactory()
+    {
+        // A multi-tenant host supplies no fixed spreadsheet; the factory is the whole point for it.
+        var provider = AddTestManager(new ServiceCollection()).BuildServiceProvider();
+
+        var factory = provider.GetService<ISheetManagerFactory<ITestManager>>();
+
+        Assert.NotNull(factory);
+    }
+
+    [Fact]
+    public void AddSheetManager_WithoutOptions_ShouldNotRegisterTheManagerItself()
+    {
+        // There is no spreadsheet to bind it to, so resolving one directly must not silently succeed.
+        var provider = AddTestManager(new ServiceCollection()).BuildServiceProvider();
+
+        Assert.Null(provider.GetService<ITestManager>());
+    }
+
+    [Fact]
+    public void AddSheetManager_WithOptions_ShouldResolveTheManager()
+    {
+        var provider = AddTestManager(new ServiceCollection(), configure: options =>
+        {
+            options.SpreadsheetId = "spreadsheet-id";
+            options.AccessToken = "ya29.mocked.token";
+        }).BuildServiceProvider();
+
+        var manager = provider.GetService<ITestManager>();
+
+        Assert.NotNull(manager);
+        Assert.NotNull(manager.Service);
+    }
+
+    [Fact]
+    public void Factory_ShouldCreateManagersForASpreadsheetChosenAtRuntime()
+    {
+        var provider = AddTestManager(new ServiceCollection()).BuildServiceProvider();
+        var factory = provider.GetRequiredService<ISheetManagerFactory<ITestManager>>();
+
+        var first = factory.Create("ya29.mocked.token", "spreadsheet-one");
+        var second = factory.Create("ya29.mocked.token", "spreadsheet-two");
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void TwoDomains_ShouldKeepTheirOwnOptionsRatherThanOverwritingEachOther()
+    {
+        // Named options are what make this work; a plain Configure<T> would have the second
+        // registration clobber the first, silently pointing one domain at the other's spreadsheet.
+        var services = new ServiceCollection();
+
+        services.AddSheetManager<ITestManager>("DomainA", (service, _) => new TestManager(service), options =>
+        {
+            options.SpreadsheetId = "spreadsheet-a";
+            options.AccessToken = "token-a";
+        });
+
+        services.AddSheetManager<IOtherTestManager>("DomainB", (service, _) => new OtherTestManager(service), options =>
+        {
+            options.SpreadsheetId = "spreadsheet-b";
+            options.AccessToken = "token-b";
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<ITestManager>());
+        Assert.NotNull(provider.GetService<IOtherTestManager>());
+    }
+
+    [Fact]
+    public void MissingSpreadsheetId_ShouldThrowAtResolutionWithAClearMessage()
+    {
+        var provider = AddTestManager(new ServiceCollection(), "Gig", options =>
+        {
+            options.AccessToken = "ya29.mocked.token";
+        }).BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => provider.GetService<ITestManager>());
+
+        Assert.Contains("SpreadsheetId", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Gig", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NoCredential_ShouldThrowAtResolution()
+    {
+        var provider = AddTestManager(new ServiceCollection(), configure: options =>
+        {
+            options.SpreadsheetId = "spreadsheet-id";
+        }).BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => provider.GetService<ITestManager>());
+
+        Assert.Contains("neither was supplied", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BothCredentialKinds_ShouldThrowRatherThanPickOneSilently()
+    {
+        var provider = AddTestManager(new ServiceCollection(), configure: options =>
+        {
+            options.SpreadsheetId = "spreadsheet-id";
+            options.AccessToken = "ya29.mocked.token";
+            options.ServiceAccountCredentials = GoogleCredentialHelpers.CreateServiceAccountParameters();
+        }).BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => provider.GetService<ITestManager>());
+
+        Assert.Contains("both were supplied", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ServiceAccountCredentials_ShouldResolveTheManager()
+    {
+        var provider = AddTestManager(new ServiceCollection(), configure: options =>
+        {
+            options.SpreadsheetId = "spreadsheet-id";
+            options.ServiceAccountCredentials = GoogleCredentialHelpers.CreateServiceAccountParameters();
+        }).BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<ITestManager>());
+    }
+
+    public interface IOtherTestManager;
+
+    private sealed class OtherTestManager(IGoogleSheetService service) : IOtherTestManager
+    {
+        public IGoogleSheetService Service { get; } = service;
+    }
+}

--- a/RaptorSheets.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/RaptorSheets.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RaptorSheets.Core.Factories;
+using RaptorSheets.Core.Options;
+using RaptorSheets.Core.Services;
+
+namespace RaptorSheets.Core.Extensions;
+
+/// <summary>
+/// Shared registration used by each domain package's own <c>AddRaptorSheets*</c> extension.
+/// Domains call this rather than re-implementing the wiring.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a domain's manager factory, plus - when <paramref name="configureOptions"/> is
+    /// supplied - a singleton manager bound to those options.
+    /// <para>
+    /// Options are registered as <em>named</em> options keyed by <paramref name="domainName"/>, so
+    /// several domains can be registered side by side against different spreadsheets without
+    /// overwriting each other's configuration.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="TManager">The domain's manager interface.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="domainName">Domain name, used as the named-options key and in error messages.</param>
+    /// <param name="create">Builds the domain's manager from a sheet service and logger.</param>
+    /// <param name="configureOptions">
+    /// Binds a fixed spreadsheet and credentials. Omit for hosts that only create managers per
+    /// request through <see cref="ISheetManagerFactory{TManager}"/>; resolving
+    /// <typeparamref name="TManager"/> directly then throws, since there is nothing to bind it to.
+    /// </param>
+    public static IServiceCollection AddSheetManager<TManager>(
+        this IServiceCollection services,
+        string domainName,
+        Func<IGoogleSheetService, ILogger?, TManager> create,
+        Action<RaptorSheetsOptions>? configureOptions = null)
+        where TManager : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domainName);
+        ArgumentNullException.ThrowIfNull(create);
+
+        if (configureOptions is not null)
+        {
+            services.Configure(domainName, configureOptions);
+        }
+
+        services.AddSingleton<SheetManagerFactory<TManager>>(provider =>
+        {
+            var logger = provider.GetService<ILoggerFactory>()?.CreateLogger($"RaptorSheets.{domainName}");
+
+            return new SheetManagerFactory<TManager>(create, logger);
+        });
+
+        services.AddSingleton<ISheetManagerFactory<TManager>>(
+            provider => provider.GetRequiredService<SheetManagerFactory<TManager>>());
+
+        if (configureOptions is not null)
+        {
+            services.AddSingleton(provider =>
+            {
+                var options = provider.GetRequiredService<IOptionsMonitor<RaptorSheetsOptions>>().Get(domainName);
+
+                return provider.GetRequiredService<SheetManagerFactory<TManager>>()
+                    .CreateFromOptions(options, domainName);
+            });
+        }
+
+        return services;
+    }
+}

--- a/RaptorSheets.Core/Factories/SheetManagerFactory.cs
+++ b/RaptorSheets.Core/Factories/SheetManagerFactory.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Logging;
+using RaptorSheets.Core.Models;
+using RaptorSheets.Core.Options;
+using RaptorSheets.Core.Services;
+
+namespace RaptorSheets.Core.Factories;
+
+/// <summary>
+/// Creates domain managers for a spreadsheet chosen at runtime rather than at registration.
+/// <para>
+/// This is the shape a multi-tenant host needs: each signed-in user has their own spreadsheet and
+/// their own credentials, so the target can't be bound once from configuration. Resolve the factory
+/// from the container and create a manager per request.
+/// </para>
+/// </summary>
+/// <typeparam name="TManager">The domain's manager interface.</typeparam>
+public interface ISheetManagerFactory<out TManager> where TManager : class
+{
+    /// <summary>Creates a manager authenticated with an OAuth access token.</summary>
+    TManager Create(string accessToken, string spreadsheetId, GoogleRetryOptions? retryOptions = null);
+
+    /// <summary>Creates a manager authenticated with service-account credential fields.</summary>
+    TManager Create(Dictionary<string, string> serviceAccountCredentials, string spreadsheetId, GoogleRetryOptions? retryOptions = null);
+}
+
+/// <summary>
+/// Default <see cref="ISheetManagerFactory{TManager}"/>, built from a domain-supplied constructor
+/// delegate so Core never needs to know the concrete manager types.
+/// </summary>
+public sealed class SheetManagerFactory<TManager> : ISheetManagerFactory<TManager> where TManager : class
+{
+    private readonly Func<IGoogleSheetService, ILogger?, TManager> _create;
+    private readonly ILogger? _logger;
+    private readonly GoogleRetryOptions _defaultRetryOptions;
+
+    public SheetManagerFactory(
+        Func<IGoogleSheetService, ILogger?, TManager> create,
+        ILogger? logger = null,
+        GoogleRetryOptions? defaultRetryOptions = null)
+    {
+        _create = create ?? throw new ArgumentNullException(nameof(create));
+        _logger = logger;
+        _defaultRetryOptions = defaultRetryOptions ?? GoogleRetryOptions.Default;
+    }
+
+    public TManager Create(string accessToken, string spreadsheetId, GoogleRetryOptions? retryOptions = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
+        ArgumentException.ThrowIfNullOrWhiteSpace(spreadsheetId);
+
+        var service = new GoogleSheetService(accessToken, spreadsheetId, _logger, retryOptions ?? _defaultRetryOptions);
+
+        return _create(service, _logger);
+    }
+
+    public TManager Create(Dictionary<string, string> serviceAccountCredentials, string spreadsheetId, GoogleRetryOptions? retryOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceAccountCredentials);
+        ArgumentException.ThrowIfNullOrWhiteSpace(spreadsheetId);
+
+        var service = new GoogleSheetService(serviceAccountCredentials, spreadsheetId, _logger, retryOptions ?? _defaultRetryOptions);
+
+        return _create(service, _logger);
+    }
+
+    /// <summary>
+    /// Creates a manager from configuration-bound options, validating them first so a misconfigured
+    /// host fails at resolution with a clear message instead of at the first API call.
+    /// </summary>
+    internal TManager CreateFromOptions(RaptorSheetsOptions options, string domainName)
+    {
+        options.Validate(domainName);
+
+        return options.ServiceAccountCredentials is { Count: > 0 } credentials
+            ? Create(credentials, options.SpreadsheetId!, options.Retry)
+            : Create(options.AccessToken!, options.SpreadsheetId!, options.Retry);
+    }
+}

--- a/RaptorSheets.Core/Options/RaptorSheetsOptions.cs
+++ b/RaptorSheets.Core/Options/RaptorSheetsOptions.cs
@@ -1,0 +1,55 @@
+namespace RaptorSheets.Core.Options;
+
+/// <summary>
+/// Binds a single spreadsheet and its credentials from configuration, for hosts that talk to one
+/// known spreadsheet. Apps where the spreadsheet varies per request or per signed-in user should use
+/// the manager factory instead - see <see cref="Factories.ISheetManagerFactory{TManager}"/>.
+/// </summary>
+public class RaptorSheetsOptions
+{
+    /// <summary>
+    /// Spreadsheet id, i.e. the segment in
+    /// <c>https://docs.google.com/spreadsheets/d/SPREADSHEET_ID/edit</c>.
+    /// </summary>
+    public string? SpreadsheetId { get; set; }
+
+    /// <summary>
+    /// OAuth access token. Mutually exclusive with <see cref="ServiceAccountCredentials"/>.
+    /// </summary>
+    public string? AccessToken { get; set; }
+
+    /// <summary>
+    /// Service-account credential fields (type, privateKeyId, privateKey, clientEmail, clientId).
+    /// Mutually exclusive with <see cref="AccessToken"/>. Keys may be camelCase or snake_case.
+    /// </summary>
+    public Dictionary<string, string>? ServiceAccountCredentials { get; set; }
+
+    /// <summary>Transient-failure retry behavior. Defaults to <see cref="Models.GoogleRetryOptions.Default"/>.</summary>
+    public Models.GoogleRetryOptions Retry { get; set; } = Models.GoogleRetryOptions.Default;
+
+    /// <summary>
+    /// Throws when the options can't produce a working client. Called during service resolution so a
+    /// misconfigured host fails at startup with a clear message rather than at the first API call.
+    /// </summary>
+    /// <param name="domainName">Domain these options were registered for, used in the error message.</param>
+    public void Validate(string domainName)
+    {
+        if (string.IsNullOrWhiteSpace(SpreadsheetId))
+        {
+            throw new InvalidOperationException(
+                $"RaptorSheets {domainName}: {nameof(SpreadsheetId)} is required.");
+        }
+
+        var hasAccessToken = !string.IsNullOrWhiteSpace(AccessToken);
+        var hasServiceAccount = ServiceAccountCredentials is { Count: > 0 };
+
+        if (hasAccessToken == hasServiceAccount)
+        {
+            var problem = hasAccessToken ? "both were supplied" : "neither was supplied";
+
+            throw new InvalidOperationException(
+                $"RaptorSheets {domainName}: exactly one of {nameof(AccessToken)} or " +
+                $"{nameof(ServiceAccountCredentials)} is required, but {problem}.");
+        }
+    }
+}

--- a/RaptorSheets.Core/RaptorSheets.Core.csproj
+++ b/RaptorSheets.Core/RaptorSheets.Core.csproj
@@ -29,7 +29,9 @@
   <ItemGroup>
     <PackageReference Include="Google.Apis.Drive.v3" Version="1.73.0.4112" />
     <PackageReference Include="Google.Apis.Sheets.v4" Version="1.73.0.4061" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/RaptorSheets.Gig.Tests/RaptorSheets.Gig.Tests.csproj
+++ b/RaptorSheets.Gig.Tests/RaptorSheets.Gig.Tests.csproj
@@ -69,6 +69,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/RaptorSheets.Gig.Tests/Unit/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/RaptorSheets.Gig.Tests/Unit/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.DependencyInjection;
+using RaptorSheets.Core.Factories;
+using RaptorSheets.Gig.Extensions;
+using RaptorSheets.Gig.Managers;
+using Xunit;
+
+namespace RaptorSheets.Gig.Tests.Unit.Extensions;
+
+/// <summary>
+/// End-to-end check that the Gig registration wires up the real manager. The generic wiring itself
+/// is covered in Core's tests; this is the domain-level smoke test.
+/// </summary>
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddRaptorSheetsGig_WithOptions_ShouldResolveTheGigManager()
+    {
+        var services = new ServiceCollection();
+
+        services.AddRaptorSheetsGig(options =>
+        {
+            options.SpreadsheetId = "spreadsheet-id";
+            options.AccessToken = "ya29.mocked.token";
+        });
+
+        var manager = services.BuildServiceProvider().GetService<IGoogleSheetManager>();
+
+        Assert.NotNull(manager);
+        Assert.IsType<GoogleSheetManager>(manager, exactMatch: false);
+    }
+
+    [Fact]
+    public void AddRaptorSheetsGig_WithoutOptions_ShouldResolveTheFactoryForPerRequestSpreadsheets()
+    {
+        var services = new ServiceCollection();
+
+        services.AddRaptorSheetsGig();
+
+        var factory = services.BuildServiceProvider()
+            .GetService<ISheetManagerFactory<IGoogleSheetManager>>();
+
+        Assert.NotNull(factory);
+
+        var manager = factory.Create("ya29.mocked.token", "some-users-spreadsheet");
+
+        Assert.NotNull(manager);
+    }
+}

--- a/RaptorSheets.Gig/Extensions/ServiceCollectionExtensions.cs
+++ b/RaptorSheets.Gig/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection;
+using RaptorSheets.Core.Extensions;
+using RaptorSheets.Core.Options;
+using RaptorSheets.Gig.Managers;
+
+namespace RaptorSheets.Gig.Extensions;
+
+/// <summary>
+/// Dependency-injection registration for the Gig domain.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Gig domain's services.
+    /// <para>
+    /// Always registers <c>ISheetManagerFactory&lt;IGoogleSheetManager&gt;</c>, for hosts where the
+    /// spreadsheet and credentials vary per request or per signed-in user.
+    /// </para>
+    /// <para>
+    /// When <paramref name="configureOptions"/> is supplied, also registers a singleton
+    /// <c>IGoogleSheetManager</c> bound to that one spreadsheet - the shape a worker or CLI wants,
+    /// with credentials bound from configuration once.
+    /// </para>
+    /// </summary>
+    /// <example>
+    /// <![CDATA[
+    /// // Fixed spreadsheet, bound from configuration
+    /// services.AddRaptorSheetsGig(options =>
+    /// {
+    ///     options.SpreadsheetId = configuration["Sheets:SpreadsheetId"];
+    ///     options.AccessToken = configuration["Sheets:AccessToken"];
+    /// });
+    ///
+    /// // Spreadsheet chosen per request
+    /// services.AddRaptorSheetsGig();
+    /// // ... then, from the factory:
+    /// var manager = factory.Create(userAccessToken, userSpreadsheetId);
+    /// ]]>
+    /// </example>
+    public static IServiceCollection AddRaptorSheetsGig(
+        this IServiceCollection services,
+        Action<RaptorSheetsOptions>? configureOptions = null)
+    {
+        return services.AddSheetManager<IGoogleSheetManager>(
+            "Gig",
+            (sheetService, logger) => new GoogleSheetManager(sheetService, logger),
+            configureOptions);
+    }
+}

--- a/RaptorSheets.Home/Extensions/ServiceCollectionExtensions.cs
+++ b/RaptorSheets.Home/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection;
+using RaptorSheets.Core.Extensions;
+using RaptorSheets.Core.Options;
+using RaptorSheets.Home.Managers;
+
+namespace RaptorSheets.Home.Extensions;
+
+/// <summary>
+/// Dependency-injection registration for the Home domain.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Home domain's services.
+    /// <para>
+    /// Always registers <c>ISheetManagerFactory&lt;IGoogleSheetManager&gt;</c>, for hosts where the
+    /// spreadsheet and credentials vary per request or per signed-in user.
+    /// </para>
+    /// <para>
+    /// When <paramref name="configureOptions"/> is supplied, also registers a singleton
+    /// <c>IGoogleSheetManager</c> bound to that one spreadsheet - the shape a worker or CLI wants,
+    /// with credentials bound from configuration once.
+    /// </para>
+    /// </summary>
+    /// <example>
+    /// <![CDATA[
+    /// // Fixed spreadsheet, bound from configuration
+    /// services.AddRaptorSheetsHome(options =>
+    /// {
+    ///     options.SpreadsheetId = configuration["Sheets:SpreadsheetId"];
+    ///     options.AccessToken = configuration["Sheets:AccessToken"];
+    /// });
+    ///
+    /// // Spreadsheet chosen per request
+    /// services.AddRaptorSheetsHome();
+    /// // ... then, from the factory:
+    /// var manager = factory.Create(userAccessToken, userSpreadsheetId);
+    /// ]]>
+    /// </example>
+    public static IServiceCollection AddRaptorSheetsHome(
+        this IServiceCollection services,
+        Action<RaptorSheetsOptions>? configureOptions = null)
+    {
+        return services.AddSheetManager<IGoogleSheetManager>(
+            "Home",
+            (sheetService, logger) => new GoogleSheetManager(sheetService, logger),
+            configureOptions);
+    }
+}

--- a/RaptorSheets.Job/Extensions/ServiceCollectionExtensions.cs
+++ b/RaptorSheets.Job/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection;
+using RaptorSheets.Core.Extensions;
+using RaptorSheets.Core.Options;
+using RaptorSheets.Job.Managers;
+
+namespace RaptorSheets.Job.Extensions;
+
+/// <summary>
+/// Dependency-injection registration for the Job domain.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Job domain's services.
+    /// <para>
+    /// Always registers <c>ISheetManagerFactory&lt;IGoogleSheetManager&gt;</c>, for hosts where the
+    /// spreadsheet and credentials vary per request or per signed-in user.
+    /// </para>
+    /// <para>
+    /// When <paramref name="configureOptions"/> is supplied, also registers a singleton
+    /// <c>IGoogleSheetManager</c> bound to that one spreadsheet - the shape a worker or CLI wants,
+    /// with credentials bound from configuration once.
+    /// </para>
+    /// </summary>
+    /// <example>
+    /// <![CDATA[
+    /// // Fixed spreadsheet, bound from configuration
+    /// services.AddRaptorSheetsJob(options =>
+    /// {
+    ///     options.SpreadsheetId = configuration["Sheets:SpreadsheetId"];
+    ///     options.AccessToken = configuration["Sheets:AccessToken"];
+    /// });
+    ///
+    /// // Spreadsheet chosen per request
+    /// services.AddRaptorSheetsJob();
+    /// // ... then, from the factory:
+    /// var manager = factory.Create(userAccessToken, userSpreadsheetId);
+    /// ]]>
+    /// </example>
+    public static IServiceCollection AddRaptorSheetsJob(
+        this IServiceCollection services,
+        Action<RaptorSheetsOptions>? configureOptions = null)
+    {
+        return services.AddSheetManager<IGoogleSheetManager>(
+            "Job",
+            (sheetService, logger) => new GoogleSheetManager(sheetService, logger),
+            configureOptions);
+    }
+}

--- a/RaptorSheets.Stock/Extensions/ServiceCollectionExtensions.cs
+++ b/RaptorSheets.Stock/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection;
+using RaptorSheets.Core.Extensions;
+using RaptorSheets.Core.Options;
+using RaptorSheets.Stock.Managers;
+
+namespace RaptorSheets.Stock.Extensions;
+
+/// <summary>
+/// Dependency-injection registration for the Stock domain.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Stock domain's services.
+    /// <para>
+    /// Always registers <c>ISheetManagerFactory&lt;IGoogleSheetManager&gt;</c>, for hosts where the
+    /// spreadsheet and credentials vary per request or per signed-in user.
+    /// </para>
+    /// <para>
+    /// When <paramref name="configureOptions"/> is supplied, also registers a singleton
+    /// <c>IGoogleSheetManager</c> bound to that one spreadsheet - the shape a worker or CLI wants,
+    /// with credentials bound from configuration once.
+    /// </para>
+    /// </summary>
+    /// <example>
+    /// <![CDATA[
+    /// // Fixed spreadsheet, bound from configuration
+    /// services.AddRaptorSheetsStock(options =>
+    /// {
+    ///     options.SpreadsheetId = configuration["Sheets:SpreadsheetId"];
+    ///     options.AccessToken = configuration["Sheets:AccessToken"];
+    /// });
+    ///
+    /// // Spreadsheet chosen per request
+    /// services.AddRaptorSheetsStock();
+    /// // ... then, from the factory:
+    /// var manager = factory.Create(userAccessToken, userSpreadsheetId);
+    /// ]]>
+    /// </example>
+    public static IServiceCollection AddRaptorSheetsStock(
+        this IServiceCollection services,
+        Action<RaptorSheetsOptions>? configureOptions = null)
+    {
+        return services.AddSheetManager<IGoogleSheetManager>(
+            "Stock",
+            (sheetService, logger) => new GoogleSheetManager(sheetService, logger),
+            configureOptions);
+    }
+}


### PR DESCRIPTION
Closes #62

Consumers had to hand-construct managers with loose credential strings, with no way to bind them from configuration or resolve an `ILogger` from the container. Each domain now has `AddRaptorSheetsGig` / `Stock` / `Job` / `Home`, backed by shared wiring in Core so domains only supply their manager constructor.

## Two usage shapes, deliberately

Writing this surfaced a question the issue didn't consider: **who actually uses this?** A single-spreadsheet worker and a multi-tenant web app need different things, and options-binding alone only serves the first.

```csharp
// Fixed spreadsheet, bound from configuration — worker/CLI
services.AddRaptorSheetsGig(options =>
{
    options.SpreadsheetId = configuration["Sheets:SpreadsheetId"];
    options.AccessToken   = configuration["Sheets:AccessToken"];
});

// Spreadsheet chosen per request — each signed-in user has their own
services.AddRaptorSheetsGig();
// ...
var manager = factory.Create(userAccessToken, userSpreadsheetId);
```

The factory is registered **always**; the singleton manager only when `configureOptions` is supplied. A per-user gig tracker — the obvious consumer — can't bind one spreadsheet at startup, so options-only DI would have been unusable for it.

## Design notes

**Named options, keyed by domain.** A plain `Configure<RaptorSheetsOptions>` would have the second domain's registration silently clobber the first, pointing one domain at the other's spreadsheet. There's a test for exactly that.

**Validation at resolution.** A missing spreadsheet id, no credential, or *both* credential kinds throws an `InvalidOperationException` naming the domain, at startup — rather than picking one silently or failing at the first API call.

**No new packages.** Registration lives in the existing Core and domain packages. Core takes `DependencyInjection.Abstractions` and `Options`, alongside the `Logging.Abstractions` it already had. Five extra NuGet packages for extension methods seemed worse than two small, ubiquitous dependencies.

## Verification

- Solution builds clean (one pre-existing unrelated warning).
- **1,628 unit tests pass**, up 11 — 9 covering the Core wiring (factory-without-options, manager-without-options *not* registered, two-domain isolation, each validation failure) and 2 as a Gig-level smoke test against the real manager.
- `dotnet pack` on Gig confirmed the new dependencies don't break packaging.

## Follow-ups, not here

The options-bound manager is a **singleton**, which is right for the fixed-spreadsheet case but means retry options can't vary per request; the factory takes a per-call override for that. This also gives #61's throttling a natural place to live now that there's a container lifetime to hang it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
