### PR TITLE
Document DI registration, retry options, and credential fail-fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,28 @@ var credentials = new Dictionary<string, string>
 var manager = new GoogleSheetManager(accessToken, spreadsheetId);
 ```
 
+### Dependency Injection
+Every domain package registers itself on `IServiceCollection`:
+
+```csharp
+using RaptorSheets.Gig.Extensions;
+
+// One spreadsheet, bound from configuration
+builder.Services.AddRaptorSheetsGig(options =>
+{
+    options.SpreadsheetId = builder.Configuration["Sheets:SpreadsheetId"];
+    options.AccessToken = builder.Configuration["Sheets:AccessToken"];
+});
+
+// Or, when each signed-in user has their own spreadsheet
+builder.Services.AddRaptorSheetsGig();
+// ... then: factory.Create(userToken, userSpreadsheetId)
+```
+
+`AddRaptorSheetsStock`, `AddRaptorSheetsJob`, and `AddRaptorSheetsHome` work the same way, and
+several domains can be registered side by side. See
+[Getting Started](docs/GETTING-STARTED.md#dependency-injection).
+
 ## 🏗️ Building Custom Packages
 
 RaptorSheets.Core with TypedField system is designed to be the foundation for domain-specific packages:

--- a/RaptorSheets.Gig/README.md
+++ b/RaptorSheets.Gig/README.md
@@ -38,6 +38,30 @@ await manager.CreateAllSheets();
 var data = await manager.GetAllSheets();
 ```
 
+### Dependency Injection
+```csharp
+using RaptorSheets.Gig.Extensions;
+
+// One spreadsheet, bound from configuration
+builder.Services.AddRaptorSheetsGig(options =>
+{
+    options.SpreadsheetId = builder.Configuration["Sheets:SpreadsheetId"];
+    options.AccessToken = builder.Configuration["Sheets:AccessToken"];
+});
+```
+
+`IGoogleSheetManager` is then injectable directly. When each signed-in user has their own
+spreadsheet, register without options and create managers per request instead:
+
+```csharp
+builder.Services.AddRaptorSheetsGig();
+
+// ... wherever you handle the request:
+var manager = factory.Create(userToken, userSpreadsheetId);
+```
+
+See [Getting Started](https://github.com/khanjal/RaptorSheets/blob/main/docs/GETTING-STARTED.md#dependency-injection) for details.
+
 ## Demo Setup
 
 Generate realistic sample data to explore RaptorSheets.Gig capabilities or set up test environments.

--- a/RaptorSheets.Home/README.md
+++ b/RaptorSheets.Home/README.md
@@ -31,4 +31,23 @@ await manager.CreateAllSheets();
 var data = await manager.GetAllSheets();
 ```
 
+### Dependency injection
+
+```csharp
+using RaptorSheets.Home.Extensions;
+
+// One spreadsheet, bound from configuration
+builder.Services.AddRaptorSheetsHome(options =>
+{
+    options.SpreadsheetId = builder.Configuration["Sheets:SpreadsheetId"];
+    options.AccessToken = builder.Configuration["Sheets:AccessToken"];
+});
+
+// Or, when the spreadsheet varies per request or per signed-in user
+builder.Services.AddRaptorSheetsHome();
+// ... then: factory.Create(userToken, userSpreadsheetId)
+```
+
+See [Getting Started](https://github.com/khanjal/RaptorSheets/blob/main/docs/GETTING-STARTED.md#dependency-injection) for details.
+
 See [RaptorSheets](https://github.com/khanjal/RaptorSheets) for authentication and full documentation.

--- a/RaptorSheets.Job/README.md
+++ b/RaptorSheets.Job/README.md
@@ -31,4 +31,23 @@ await manager.SetupDemo();
 var data = await manager.GetAllSheets();
 ```
 
+### Dependency injection
+
+```csharp
+using RaptorSheets.Job.Extensions;
+
+// One spreadsheet, bound from configuration
+builder.Services.AddRaptorSheetsJob(options =>
+{
+    options.SpreadsheetId = builder.Configuration["Sheets:SpreadsheetId"];
+    options.AccessToken = builder.Configuration["Sheets:AccessToken"];
+});
+
+// Or, when the spreadsheet varies per request or per signed-in user
+builder.Services.AddRaptorSheetsJob();
+// ... then: factory.Create(userToken, userSpreadsheetId)
+```
+
+See [Getting Started](https://github.com/khanjal/RaptorSheets/blob/main/docs/GETTING-STARTED.md#dependency-injection) for details.
+
 See [RaptorSheets](https://github.com/khanjal/RaptorSheets) for authentication and full documentation.

--- a/RaptorSheets.Stock/README.md
+++ b/RaptorSheets.Stock/README.md
@@ -52,6 +52,25 @@ Console.WriteLine($"Accounts: {data.Sheets.Accounts.Count}, Stocks: {data.Sheets
 var subset = await manager.GetSheets(new List<string> { SheetEnum.ACCOUNTS.GetDescription() });
 ```
 
+### Dependency injection
+
+```csharp
+using RaptorSheets.Stock.Extensions;
+
+// One spreadsheet, bound from configuration
+builder.Services.AddRaptorSheetsStock(options =>
+{
+    options.SpreadsheetId = builder.Configuration["Sheets:SpreadsheetId"];
+    options.AccessToken = builder.Configuration["Sheets:AccessToken"];
+});
+
+// Or, when the spreadsheet varies per request or per signed-in user
+builder.Services.AddRaptorSheetsStock();
+// ... then: factory.Create(userToken, userSpreadsheetId)
+```
+
+See [Getting Started](https://github.com/khanjal/RaptorSheets/blob/main/docs/GETTING-STARTED.md#dependency-injection) for details.
+
 ## Data Operations
 
 ### Creating and Deleting Sheets

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -44,6 +44,53 @@ Low-level wrapper around Google Sheets API.
 | `UpdateValues(string spreadsheetId, string range, ValueRange valueRange)` | Update cell values |
 | `BatchUpdate(string spreadsheetId, BatchUpdateSpreadsheetRequest request)` | Batch operations |
 
+### Dependency Injection
+
+Each domain package exposes `AddRaptorSheets{Domain}` on `IServiceCollection`, backed by shared
+wiring in Core.
+
+| Registration | Registers |
+|--------------|-----------|
+| `AddRaptorSheets{Domain}()` | `ISheetManagerFactory<IGoogleSheetManager>` only |
+| `AddRaptorSheets{Domain}(options => ...)` | The factory **and** a singleton `IGoogleSheetManager` bound to those options |
+
+#### RaptorSheetsOptions
+
+| Property | Description |
+|----------|-------------|
+| `SpreadsheetId` | Required. The id segment of the spreadsheet URL. |
+| `AccessToken` | OAuth access token. Mutually exclusive with `ServiceAccountCredentials`. |
+| `ServiceAccountCredentials` | Service-account fields; keys may be camelCase or snake_case. Mutually exclusive with `AccessToken`. |
+| `Retry` | `GoogleRetryOptions` for transient-failure handling. |
+
+Validated at resolution — a missing spreadsheet id, no credential, or both credential kinds throws
+an `InvalidOperationException` naming the domain.
+
+#### ISheetManagerFactory&lt;TManager&gt;
+
+For spreadsheets chosen at runtime rather than at registration.
+
+| Method | Description |
+|--------|-------------|
+| `Create(string accessToken, string spreadsheetId, GoogleRetryOptions? retryOptions = null)` | Manager authenticated with an access token |
+| `Create(Dictionary<string, string> credentials, string spreadsheetId, GoogleRetryOptions? retryOptions = null)` | Manager authenticated with service-account credentials |
+
+### GoogleRetryOptions
+
+Controls automatic retry of transient Google API failures — 429 rate limiting, 503s, and transport
+exceptions. Passed via `RaptorSheetsOptions.Retry`, the factory's `retryOptions` argument, or the
+manager/service constructors.
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `Enabled` | `true` | Set false to surface transient failures immediately. |
+| `MaxRetries` | `3` | Attempts before the error is surfaced. Max 20. |
+| `BackOffDelta` | `1s` | **Base unit of the exponential curve, not the first delay.** Waits are roughly `delta * (2^attempt - 1)` with jitter. Max 1s — the underlying client rejects more. |
+| `MaxDelay` | `8s` | Ceiling on any single wait; beyond it, retrying stops. |
+
+At the defaults, actual waits land near 1.5s, 2.9s, and 4.3s — under ~9 seconds total, which fits
+inside a 30 second gateway timeout with room for the requests themselves.
+
 ### SheetHelpers
 
 Utility methods for sheet operations.

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -265,6 +265,8 @@ public bool ValidateServiceAccountCredentials(Dictionary<string, string> credent
 }
 ```
 
+> **Unusable credentials fail at construction.** Creating a manager with a private key that isn't valid PEM-encoded RSA key material throws an `ArgumentException` naming the offending parameter, rather than constructing successfully and failing with an opaque 401 on the first API call. The check above is still useful for reporting *which* field is missing before you get that far.
+
 ## Configuration Examples
 
 ### ASP.NET Core Configuration
@@ -281,25 +283,40 @@ public bool ValidateServiceAccountCredentials(Dictionary<string, string> credent
   "SpreadsheetId": "your-spreadsheet-id"
 }
 
-// Startup.cs or Program.cs
-services.Configure<GoogleCredentials>(configuration.GetSection("GoogleCredentials"));
-services.AddScoped<IGoogleSheetManager>(provider =>
+// Program.cs
+using RaptorSheets.Gig.Extensions;
+
+builder.Services.AddRaptorSheetsGig(options =>
 {
-    var credentials = provider.GetService<IOptions<GoogleCredentials>>().Value;
-    var spreadsheetId = configuration["SpreadsheetId"];
-    
-    var credentialDict = new Dictionary<string, string>
-    {
-        ["type"] = credentials.Type,
-        ["private_key_id"] = credentials.PrivateKeyId,
-        ["private_key"] = credentials.PrivateKey,
-        ["client_email"] = credentials.ClientEmail,
-        ["client_id"] = credentials.ClientId
-    };
-    
-    return new GoogleSheetManager(credentialDict, spreadsheetId);
+    options.SpreadsheetId = builder.Configuration["SpreadsheetId"];
+    options.ServiceAccountCredentials = builder.Configuration
+        .GetSection("GoogleCredentials")
+        .Get<Dictionary<string, string>>();
 });
 ```
+
+`IGoogleSheetManager` is then injectable directly. Credential keys may be camelCase or snake_case.
+
+If the spreadsheet is not fixed at startup — the usual case when each signed-in user has their own — register without options and create managers per request instead:
+
+```csharp
+builder.Services.AddRaptorSheetsGig();
+
+// then, wherever you handle the request:
+public class TripsController(ISheetManagerFactory<IGoogleSheetManager> factory)
+{
+    public async Task<IActionResult> Get(string userToken, string userSpreadsheetId)
+    {
+        var manager = factory.Create(userToken, userSpreadsheetId);
+        var sheet = await manager.GetSheet("Trips");
+        return Ok(sheet);
+    }
+}
+```
+
+Substitute `AddRaptorSheetsStock`, `AddRaptorSheetsJob`, or `AddRaptorSheetsHome` for other domains. Several domains can be registered side by side against different spreadsheets.
+
+> **Configuration is validated when the manager is resolved.** A missing `SpreadsheetId`, no credential, or *both* an access token and service-account credentials throws at startup with a message naming the domain, rather than failing at the first API call.
 
 ### Console Application with User Secrets
 ```bash

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -7,7 +7,8 @@ This guide will help you get up and running with RaptorSheets quickly, whether y
 2. [Prerequisites](#prerequisites)
 3. [Authentication Setup](#authentication-setup)
 4. [Quick Start Examples](#quick-start-examples)
-5. [Next Steps](#next-steps)
+5. [Dependency Injection](#dependency-injection)
+6. [Next Steps](#next-steps)
 
 ## Choose Your Package
 
@@ -177,6 +178,58 @@ foreach (var sheet in response.Sheets)
 var allData = await manager.GetSheets();
 ```
 
+## Dependency Injection
+
+Every domain package ships an `IServiceCollection` extension, so credentials come from configuration
+and the logger comes from the container. There are two shapes, depending on whether the spreadsheet
+is known at startup.
+
+### One spreadsheet, bound from configuration
+
+The shape a worker service or CLI wants:
+
+```csharp
+using RaptorSheets.Gig.Extensions;
+
+builder.Services.AddRaptorSheetsGig(options =>
+{
+    options.SpreadsheetId = builder.Configuration["Sheets:SpreadsheetId"];
+    options.AccessToken = builder.Configuration["Sheets:AccessToken"];
+});
+```
+
+`IGoogleSheetManager` is then injectable directly.
+
+### A different spreadsheet per request
+
+The shape a multi-tenant app wants, where each signed-in user has their own spreadsheet and
+credentials. Register without options and resolve the factory:
+
+```csharp
+builder.Services.AddRaptorSheetsGig();
+
+// ...
+
+public class TripsService(ISheetManagerFactory<IGoogleSheetManager> factory)
+{
+    public Task<SheetEntity> GetTripsAsync(string userToken, string userSpreadsheetId)
+    {
+        var manager = factory.Create(userToken, userSpreadsheetId);
+        return manager.GetSheet("Trips");
+    }
+}
+```
+
+The factory is registered either way, so you can bind a default spreadsheet *and* still create
+managers for other spreadsheets at runtime.
+
+`AddRaptorSheetsStock`, `AddRaptorSheetsJob`, and `AddRaptorSheetsHome` work identically, and several
+domains can be registered side by side against different spreadsheets.
+
+> Options are validated when the manager is resolved. A missing `SpreadsheetId`, no credential, or
+> both an access token *and* service-account credentials throws at startup with a message naming the
+> domain — not at the first API call.
+
 ## Next Steps
 
 ### For RaptorSheets.Core Users
@@ -204,7 +257,29 @@ var allData = await manager.GetSheets();
 ### Quota Limits
 - Google Sheets API has rate limits (100 requests per 100 seconds)
 - Use batch operations for bulk data operations
-- RaptorSheets automatically handles retries
+- RaptorSheets retries transient failures automatically — rate limiting (429), 503s, and transport
+  exceptions — with exponential backoff. Defaults keep the total wait under about 9 seconds so a
+  retry burst can't consume a typical request budget.
+- Tune or disable it with `GoogleRetryOptions`:
+
+```csharp
+var manager = new GoogleSheetManager(accessToken, spreadsheetId);
+
+// or, with explicit retry behavior:
+services.AddRaptorSheetsGig(options =>
+{
+    options.SpreadsheetId = spreadsheetId;
+    options.AccessToken = accessToken;
+    options.Retry = new GoogleRetryOptions
+    {
+        MaxRetries = 5,
+        BackOffDelta = TimeSpan.FromSeconds(1),  // exponential base unit, max 1s
+        MaxDelay = TimeSpan.FromSeconds(8)       // ceiling on any single wait
+    };
+});
+```
+
+If a 429 still surfaces after retries, the quota is genuinely exhausted rather than merely contended.
 
 ### Permission Errors
 - Share your spreadsheet with the service account email


### PR DESCRIPTION
Docs catch-up for #60, #62, and #66.

**Nothing in the existing docs was wrong.** All three changes were additive — retry is an optional parameter with unchanged defaults, #63 was build-only, and `new GoogleSheetManager(credentials, spreadsheetId)` still behaves exactly as documented. The gaps were things undocumented or understated.

## What changed

**Dependency injection** — both shapes, in Getting Started (new section + TOC entry), the API reference, the root README, and all four domain READMEs. The options-bound singleton for a fixed spreadsheet, and the factory for the multi-tenant case where each signed-in user has their own.

The hand-rolled ASP.NET Core registration in the authentication guide is now `AddRaptorSheetsGig` — that snippet was building the credential dictionary and constructing the manager by hand, which is precisely what the extension does now.

**`GoogleRetryOptions`** — a reference table leading with the non-obvious part: `BackOffDelta` is the exponential *base unit*, not the first delay, and the underlying client caps it at one second. Anyone setting it to "2 seconds because I want a 2 second delay" gets an exception, which is the mistake I made implementing it.

**Credential fail-fast** — a note that unusable key material now throws at construction rather than failing later as an opaque 401. Worth flagging since it's the one observable behavior change in the batch.

## One correction

Getting Started claimed *"RaptorSheets automatically handles retries."* That was aspirational when written — there was no retry policy at all before #60. It's true now, so it stays, but restated with what's actually covered (429, 503, transport exceptions) and what the defaults cost in wall-clock time (~9s worst case, sized against a 30s request budget).

## Verification

Docs-only; solution still builds clean. All code samples correspond to API surface covered by existing tests — the DI registrations, the factory calls, and the `GoogleRetryOptions` object initializer are each exercised in `ServiceCollectionExtensionsTests` and `GoogleRetryOptionsTests`.

Domain READMEs link to Getting Started by absolute URL rather than relative path, since they're packed into the NuGet packages where relative links break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
