### PR TITLE
Restore Validation self-heal, fix append/update data loss, split protected-sheet deletes, and reapply drifted formulas

### DIFF
--- a/RaptorSheets.Core.Tests/Unit/Helpers/ColumnInsertionHelperTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/ColumnInsertionHelperTests.cs
@@ -164,6 +164,40 @@ public class ColumnInsertionHelperTests
     }
 
     [Fact]
+    public void BuildInsertRequests_WithValidationRule_AlsoAddsColumnValidationRequest()
+    {
+        // #103: a re-inserted dropdown column must get its validation rule back, not just its
+        // header text/format.
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Widgets"] = [new ColumnInsertionInfo { SheetName = "Widgets", SheetId = 5, ColumnIndex = 2, ColumnName = "Service", ValidationRule = new DataValidationRule() }]
+        };
+
+        var requests = ColumnInsertionHelper.BuildInsertRequests(missingColumns);
+
+        // Insert + header update + validation reapply = 3 requests for this one column.
+        Assert.Equal(3, requests.Count);
+        var validationRequest = requests.Single(r => r.RepeatCell != null);
+        Assert.Equal(2, validationRequest.RepeatCell.Range.StartColumnIndex);
+        Assert.NotNull(validationRequest.RepeatCell.Cell.DataValidation);
+    }
+
+    [Fact]
+    public void BuildInsertRequests_WithFormatAndValidationRule_AddsBothRequests()
+    {
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Widgets"] = [new ColumnInsertionInfo { SheetName = "Widgets", SheetId = 5, ColumnIndex = 2, ColumnName = "Service", Format = Format.ACCOUNTING, ValidationRule = new DataValidationRule() }]
+        };
+
+        var requests = ColumnInsertionHelper.BuildInsertRequests(missingColumns);
+
+        // Insert + header update + format reapply + validation reapply = 4 requests.
+        Assert.Equal(4, requests.Count);
+        Assert.Equal(2, requests.Count(r => r.RepeatCell != null));
+    }
+
+    [Fact]
     public async Task InsertMissingColumnsAsync_WithNoMissingColumns_ReturnsInfoMessageWithoutCallingService()
     {
         var mockService = new Mock<IGoogleSheetService>();
@@ -210,5 +244,51 @@ public class ColumnInsertionHelperTests
         var result = await ColumnInsertionHelper.InsertMissingColumnsAsync<TestSheetEntity>(mockService.Object, missingColumns);
 
         Assert.Contains(result.Messages, m => m.Message.Contains("Failed to insert missing columns"));
+    }
+
+    [Fact]
+    public void BuildHeaderFixRequests_WithBrokenColumn_WritesCanonicalFormulaToHeaderCellOnly()
+    {
+        // #53 gap 3: reapplying a drifted existing column's formula must touch only that column's
+        // header cell (row 0) - never an InsertDimension (the column already exists) and never the
+        // data rows beneath it.
+        var brokenColumns = new List<ColumnInsertionInfo>
+        {
+            new() { SheetName = "Widgets", SheetId = 5, ColumnIndex = 2, ColumnLetter = "C", ColumnName = "Total", Formula = "=SUM(A:A)" }
+        };
+
+        var requests = ColumnInsertionHelper.BuildHeaderFixRequests(brokenColumns);
+
+        var request = Assert.Single(requests);
+        Assert.Null(request.InsertDimension);
+        Assert.NotNull(request.UpdateCells);
+        Assert.Equal(5, request.UpdateCells.Range.SheetId);
+        Assert.Equal(0, request.UpdateCells.Range.StartRowIndex);
+        Assert.Equal(2, request.UpdateCells.Range.StartColumnIndex);
+        Assert.Equal("=SUM(A:A)", request.UpdateCells.Rows[0].Values[0].UserEnteredValue.FormulaValue);
+        Assert.Equal("userEnteredValue,note", request.UpdateCells.Fields);
+    }
+
+    [Fact]
+    public void BuildHeaderFixRequests_WithMultipleBrokenColumns_ReturnsOneRequestPerColumn()
+    {
+        var brokenColumns = new List<ColumnInsertionInfo>
+        {
+            new() { SheetName = "Widgets", SheetId = 5, ColumnIndex = 1, ColumnName = "B", Formula = "=A1" },
+            new() { SheetName = "Widgets", SheetId = 5, ColumnIndex = 3, ColumnName = "D", Formula = "=C1" }
+        };
+
+        var requests = ColumnInsertionHelper.BuildHeaderFixRequests(brokenColumns);
+
+        Assert.Equal(2, requests.Count);
+        Assert.All(requests, r => Assert.NotNull(r.UpdateCells));
+    }
+
+    [Fact]
+    public void BuildHeaderFixRequests_WithNoBrokenColumns_ReturnsEmptyList()
+    {
+        var requests = ColumnInsertionHelper.BuildHeaderFixRequests([]);
+
+        Assert.Empty(requests);
     }
 }

--- a/RaptorSheets.Core.Tests/Unit/Helpers/GoogleRequestHelpersTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/GoogleRequestHelpersTests.cs
@@ -356,6 +356,45 @@ public class GoogleRequestHelpersTests
     }
 
     [Fact]
+    public void GenerateColumnValidationRequest_WithValidation_ShouldReturnRepeatCellRequestForThatColumn()
+    {
+        // Act
+        var result = GoogleRequestHelpers.GenerateColumnValidationRequest(sheetId: 7, columnIndex: 3, validation: new DataValidationRule());
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result!.RepeatCell);
+        Assert.Equal(7, result.RepeatCell.Range.SheetId);
+        Assert.Equal(3, result.RepeatCell.Range.StartColumnIndex);
+        Assert.Equal(4, result.RepeatCell.Range.EndColumnIndex);
+        Assert.Equal(1, result.RepeatCell.Range.StartRowIndex);
+        Assert.NotNull(result.RepeatCell.Cell.DataValidation);
+    }
+
+    [Fact]
+    public void GenerateColumnValidationRequest_ShouldScopeFieldsMaskToDataValidationOnly()
+    {
+        // Regression guard: mirrors GenerateColumnFormatRequest's own guard - this request must
+        // never use a broad field mask that could clear existing values, format, or notes on a
+        // live, already-populated column.
+        var result = GoogleRequestHelpers.GenerateColumnValidationRequest(sheetId: 1, columnIndex: 0, validation: new DataValidationRule());
+
+        Assert.Equal(Field.DATA_VALIDATION.GetDescription(), result!.RepeatCell.Fields);
+        Assert.Null(result.RepeatCell.Cell.UserEnteredValue);
+        Assert.Null(result.RepeatCell.Cell.UserEnteredFormat);
+    }
+
+    [Fact]
+    public void GenerateColumnValidationRequest_WithNullValidation_ShouldReturnNull()
+    {
+        // Act
+        var result = GoogleRequestHelpers.GenerateColumnValidationRequest(sheetId: 1, columnIndex: 0, validation: null);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
     public void GenerateSheetPropertes_ShouldReturnValidRequest()
     {
         // Arrange

--- a/RaptorSheets.Core.Tests/Unit/Helpers/HeaderHelpersTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/HeaderHelpersTests.cs
@@ -502,6 +502,29 @@ public class HeaderHelpersTests
     }
 
     [Fact]
+    public void CheckSheetHeaders_WithMissingColumn_ShouldCarryRawValidationName()
+    {
+        // #103: the raw Validation name must survive detection so a domain's SheetManagerBase
+        // override (GetDataValidation) can resolve it into a concrete DataValidationRule later.
+        var values = new List<object> { "Header1" };
+        var sheetModel = new SheetModel
+        {
+            Name = "TestSheet",
+            Headers =
+            [
+                new SheetCellModel { Name = "Header1" },
+                new SheetCellModel { Name = "Header2", Validation = "RANGE_SERVICE" }
+            ]
+        };
+
+        HeaderHelpers.CheckSheetHeaders(values, sheetModel, out var insertionInfo);
+
+        var missing = Assert.Single(insertionInfo);
+        Assert.Equal("RANGE_SERVICE", missing.Validation);
+        Assert.Null(missing.ValidationRule); // resolved later by SheetManagerBase, not at detection time
+    }
+
+    [Fact]
     public void CheckSheetHeaders_WithNoMissingColumns_ShouldReturnEmptyInsertionInfo()
     {
         var values = new List<object> { "Header1", "Header2" };

--- a/RaptorSheets.Core.Tests/Unit/Managers/SheetManagerGenericBaseTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Managers/SheetManagerGenericBaseTests.cs
@@ -760,6 +760,30 @@ public class SheetManagerGenericBaseTests
     }
 
     [Fact]
+    public async Task DetectBrokenColumnsAsync_WithDuplicateOrBlankLiveHeaderNames_DoesNotThrow()
+    {
+        // Copilot review on PR #104: a live sheet can genuinely have duplicate or blank header
+        // names (cells cleared/renamed by hand) - detection must tolerate that rather than crash
+        // the whole check with a ToDictionary key collision.
+        var headers = new List<SheetCellModel> { new() { Name = "Date" }, new() { Name = "Total", Formula = "=SUM(A:A)" } };
+        var registry = BuildRegistryWithHeaders(SheetName, headers);
+        var spreadsheet = BuildLiveStructureSpreadsheet(SheetName, 42,
+            ("", null),                 // blank header name
+            ("Total", "=SUM(A:A)"),     // first "Total" - matches canonical
+            ("Total", "=OLD_BROKEN"));  // duplicate "Total" - would collide in a plain ToDictionary
+
+        var mockService = new Mock<IGoogleSheetService>();
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        var manager = new TestManagerWithGeneration(mockService.Object, registry, [SheetName]);
+
+        var broken = await manager.DetectBrokenColumnsAsync(SheetName);
+
+        // First occurrence of "Total" wins and matches canonical, so nothing is flagged.
+        Assert.Empty(broken);
+    }
+
+    [Fact]
     public async Task ReapplyColumnFormulas_WithBrokenColumns_CallsBatchUpdateAndReportsSuccess()
     {
         var mockService = new Mock<IGoogleSheetService>();
@@ -788,6 +812,34 @@ public class SheetManagerGenericBaseTests
 
         Assert.Contains(result.Messages, m => m.Message.Contains("No broken columns to reapply"));
         mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InsertMissingColumns_WithAlreadyResolvedValidationRule_DoesNotOverwriteIt()
+    {
+        // Copilot review on PR #104: a caller of the public InsertMissingColumns API may already
+        // have populated ValidationRule directly. TestManagerWithGeneration doesn't override
+        // GetDataValidation (base class no-op, always returns null) - if resolution unconditionally
+        // overwrote an already-set rule, it would silently wipe this one out.
+        var mockService = new Mock<IGoogleSheetService>();
+        BatchUpdateSpreadsheetRequest? capturedRequest = null;
+        mockService
+            .Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => capturedRequest = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = BuildGeneratingManager(mockService.Object);
+        var preResolvedRule = new DataValidationRule { Condition = new BooleanCondition { Type = "BOOLEAN" } };
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            [SheetName] = [new ColumnInsertionInfo { SheetName = SheetName, SheetId = 1, ColumnIndex = 0, ColumnName = "Active", ValidationRule = preResolvedRule }]
+        };
+
+        await manager.InsertMissingColumns(missingColumns);
+
+        Assert.NotNull(capturedRequest);
+        var validationRequest = capturedRequest.Requests.Single(r => r.RepeatCell != null);
+        Assert.Same(preResolvedRule, validationRequest.RepeatCell.Cell.DataValidation);
     }
 
     // RefreshHeaderFormulasAsync / RefreshDependentSheetsAsync - the automated replacement for

--- a/RaptorSheets.Core.Tests/Unit/Managers/SheetManagerGenericBaseTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Managers/SheetManagerGenericBaseTests.cs
@@ -527,6 +527,269 @@ public class SheetManagerGenericBaseTests
         Assert.Contains(result.Messages, m => m.Message.Contains("Error deleting sheets") && m.Message.Contains("boom"));
     }
 
+    // #102: Google 500s deleting 2+ protected sheets in one batch (reproduced 5/5 live against
+    // Stock's Accounts/Tickers). DeleteSheets splits into separate batch calls once 2+ of the
+    // sheets being deleted are protected; 0 or 1 protected sheet keeps the single-batch path above
+    // completely unchanged (see IsProtectedSheet/ExecuteSplitDeleteAsync).
+
+    private static SheetRegistry<TestEntity> BuildRegistryWithProtection(params (string Name, bool Protect)[] sheets)
+    {
+        var registry = new SheetRegistry<TestEntity>();
+        foreach (var (name, protect) in sheets)
+        {
+            registry.Register(name, () => new SheetModel { Name = name, ProtectSheet = protect }, (_, _) => { });
+        }
+        return registry;
+    }
+
+    [Fact]
+    public async Task DeleteSheets_With2PlusProtectedSheets_SplitsIntoSeparateBatchCalls()
+    {
+        const string Unprotected = "Stocks";
+        const string ProtectedA = "Accounts";
+        const string ProtectedB = "Tickers";
+
+        var registry = BuildRegistryWithProtection((Unprotected, false), (ProtectedA, true), (ProtectedB, true));
+        var mockService = new Mock<IGoogleSheetService>();
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets = new List<Sheet>
+            {
+                new() { Properties = new SheetProperties { Title = Unprotected, SheetId = 1 } },
+                new() { Properties = new SheetProperties { Title = ProtectedA, SheetId = 2 } },
+                new() { Properties = new SheetProperties { Title = ProtectedB, SheetId = 3 } }
+            }
+        };
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        var capturedRequests = new List<BatchUpdateSpreadsheetRequest>();
+        mockService.Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => capturedRequests.Add(r))
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse { Replies = new List<Response>() });
+
+        var manager = new TestManagerWithGeneration(mockService.Object, registry, [Unprotected, ProtectedA, ProtectedB]);
+
+        var result = await manager.DeleteSheets([Unprotected, ProtectedA, ProtectedB]);
+
+        // 3 separate calls: one grouped call (unprotected sheet + temp-sheet safety net, since all
+        // 3 canonical sheets are being deleted), plus one call per protected sheet.
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+
+        Assert.Contains(capturedRequests[0].Requests, r => r.AddSheet != null && r.AddSheet.Properties.Title == SheetManagerBase.TempSheetName);
+        Assert.Contains(capturedRequests[0].Requests, r => r.DeleteSheet != null && r.DeleteSheet.SheetId == 1);
+
+        var laterDeletedIds = capturedRequests.Skip(1)
+            .SelectMany(r => r.Requests)
+            .Where(r => r.DeleteSheet != null)
+            .Select(r => r.DeleteSheet.SheetId)
+            .ToList();
+        Assert.Equal([2, 3], laterDeletedIds);
+        // Each protected sheet gets its own call, containing nothing but that one delete.
+        Assert.All(capturedRequests.Skip(1), r => Assert.Single(r.Requests));
+
+        Assert.Equal(3, result.Messages.Count(m => m.Message.Contains("Sheet deletion completed successfully")));
+    }
+
+    [Fact]
+    public async Task DeleteSheets_With1ProtectedSheet_StaysOnSingleBatchCall()
+    {
+        // Boundary guard: exactly 1 protected sheet must NOT trigger the split path.
+        const string Unprotected = "Stocks";
+        const string ProtectedA = "Accounts";
+
+        var registry = BuildRegistryWithProtection((Unprotected, false), (ProtectedA, true));
+        var mockService = new Mock<IGoogleSheetService>();
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets = new List<Sheet>
+            {
+                new() { Properties = new SheetProperties { Title = Unprotected, SheetId = 1 } },
+                new() { Properties = new SheetProperties { Title = ProtectedA, SheetId = 2 } }
+            }
+        };
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+        mockService.Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse { Replies = new List<Response>() });
+
+        var manager = new TestManagerWithGeneration(mockService.Object, registry, [Unprotected, ProtectedA]);
+
+        var result = await manager.DeleteSheets([Unprotected, ProtectedA]);
+
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains(result.Messages, m => m.Message.Contains("Sheet deletion completed successfully"));
+    }
+
+    [Fact]
+    public async Task DeleteSheets_With2PlusProtectedSheets_WhenOneCallFails_StillAttemptsTheRest()
+    {
+        // A caller relying on "delete everything" shouldn't be stuck just because one protected
+        // sheet's call failed - the others should still be attempted, with failure reported
+        // per-call rather than aborting the whole operation. An untouched "Other" sheet is included
+        // so no temp-sheet call is needed here, keeping this test focused on the fail/continue
+        // behavior rather than the temp-sheet call already covered above.
+        const string ProtectedA = "Accounts";
+        const string ProtectedB = "Tickers";
+        const string Other = "Other";
+
+        var registry = BuildRegistryWithProtection((ProtectedA, true), (ProtectedB, true), (Other, false));
+        var mockService = new Mock<IGoogleSheetService>();
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets = new List<Sheet>
+            {
+                new() { Properties = new SheetProperties { Title = ProtectedA, SheetId = 2 } },
+                new() { Properties = new SheetProperties { Title = ProtectedB, SheetId = 3 } },
+                new() { Properties = new SheetProperties { Title = Other, SheetId = 4 } }
+            }
+        };
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+        mockService.SetupSequence(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BatchUpdateSpreadsheetResponse?)null)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse { Replies = new List<Response>() });
+
+        var manager = new TestManagerWithGeneration(mockService.Object, registry, [ProtectedA, ProtectedB, Other]);
+
+        var result = await manager.DeleteSheets([ProtectedA, ProtectedB]);
+
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        Assert.Contains(result.Messages, m => m.Message.Contains("Sheet deletion failed"));
+        Assert.Contains(result.Messages, m => m.Message.Contains("Sheet deletion completed successfully"));
+    }
+
+    // DetectBrokenColumnsAsync / ReapplyColumnFormulas (#53 gaps 2/3) - detecting and fixing a
+    // column that already exists under the same name on both sides but whose live Formula has
+    // drifted from canonical. Distinct from missing-column self-heal, which is covered elsewhere.
+
+    private static SheetRegistry<TestEntity> BuildRegistryWithHeaders(string sheetName, List<SheetCellModel> headers)
+    {
+        var registry = new SheetRegistry<TestEntity>();
+        registry.Register(sheetName, () => new SheetModel { Name = sheetName, Headers = headers }, (_, _) => { });
+        return registry;
+    }
+
+    private static Spreadsheet BuildLiveStructureSpreadsheet(string sheetName, int sheetId, params (string Name, string? Formula)[] liveHeaders)
+    {
+        return new Spreadsheet
+        {
+            Sheets = new List<Sheet>
+            {
+                new()
+                {
+                    Properties = new SheetProperties { Title = sheetName, SheetId = sheetId },
+                    Data = new List<GridData>
+                    {
+                        new()
+                        {
+                            RowData = new List<RowData>
+                            {
+                                new()
+                                {
+                                    Values = liveHeaders.Select(h => new CellData
+                                    {
+                                        FormattedValue = h.Name,
+                                        UserEnteredValue = string.IsNullOrEmpty(h.Formula) ? null : new ExtendedValue { FormulaValue = h.Formula }
+                                    }).ToList()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public async Task DetectBrokenColumnsAsync_WithDriftedFormula_ReturnsCanonicalFixAtLivePosition()
+    {
+        var headers = new List<SheetCellModel> { new() { Name = "Date" }, new() { Name = "Total", Formula = "=SUM(A:A)" } };
+        var registry = BuildRegistryWithHeaders(SheetName, headers);
+        var spreadsheet = BuildLiveStructureSpreadsheet(SheetName, 42, ("Date", null), ("Total", "=OLD_BROKEN_FORMULA"));
+
+        var mockService = new Mock<IGoogleSheetService>();
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        var manager = new TestManagerWithGeneration(mockService.Object, registry, [SheetName]);
+
+        var broken = await manager.DetectBrokenColumnsAsync(SheetName);
+
+        var column = Assert.Single(broken);
+        Assert.Equal("Total", column.ColumnName);
+        Assert.Equal("=SUM(A:A)", column.Formula); // canonical - ready to reapply, not the drifted live one
+        Assert.Equal(42, column.SheetId);
+        Assert.Equal(1, column.ColumnIndex);
+        Assert.Equal("B", column.ColumnLetter);
+    }
+
+    [Fact]
+    public async Task DetectBrokenColumnsAsync_WithMatchingFormula_ReturnsEmpty()
+    {
+        var headers = new List<SheetCellModel> { new() { Name = "Date" }, new() { Name = "Total", Formula = "=SUM(A:A)" } };
+        var registry = BuildRegistryWithHeaders(SheetName, headers);
+        var spreadsheet = BuildLiveStructureSpreadsheet(SheetName, 42, ("Date", null), ("Total", "=SUM(A:A)"));
+
+        var mockService = new Mock<IGoogleSheetService>();
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        var manager = new TestManagerWithGeneration(mockService.Object, registry, [SheetName]);
+
+        var broken = await manager.DetectBrokenColumnsAsync(SheetName);
+
+        Assert.Empty(broken);
+    }
+
+    [Fact]
+    public async Task DetectBrokenColumnsAsync_WithMissingColumn_DoesNotFlagIt()
+    {
+        // A column absent from the live sheet entirely is missing-column self-heal's job, not this
+        // one's - it must not also show up here as "broken".
+        var headers = new List<SheetCellModel> { new() { Name = "Date" }, new() { Name = "Total", Formula = "=SUM(A:A)" } };
+        var registry = BuildRegistryWithHeaders(SheetName, headers);
+        var spreadsheet = BuildLiveStructureSpreadsheet(SheetName, 42, ("Date", null)); // "Total" missing entirely
+
+        var mockService = new Mock<IGoogleSheetService>();
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        var manager = new TestManagerWithGeneration(mockService.Object, registry, [SheetName]);
+
+        var broken = await manager.DetectBrokenColumnsAsync(SheetName);
+
+        Assert.Empty(broken);
+    }
+
+    [Fact]
+    public async Task ReapplyColumnFormulas_WithBrokenColumns_CallsBatchUpdateAndReportsSuccess()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        mockService.Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = BuildGeneratingManager(mockService.Object);
+        var broken = new List<ColumnInsertionInfo>
+        {
+            new() { SheetName = SheetName, SheetId = 1, ColumnIndex = 1, ColumnName = "Total", Formula = "=SUM(A:A)" }
+        };
+
+        var result = await manager.ReapplyColumnFormulas(SheetName, broken);
+
+        Assert.Contains(result.Messages, m => m.Message.Contains("Reapplied formula for 1 column"));
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReapplyColumnFormulas_WithNoBrokenColumns_DoesNotCallService()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        var manager = BuildGeneratingManager(mockService.Object);
+
+        var result = await manager.ReapplyColumnFormulas(SheetName, []);
+
+        Assert.Contains(result.Messages, m => m.Message.Contains("No broken columns to reapply"));
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     // RefreshHeaderFormulasAsync / RefreshDependentSheetsAsync - the automated replacement for
     // manually "reapplying" a sheet to fix a stale cross-sheet formula reference (#REF!/#ERROR!/
     // #N/A caused by a referenced sheet's headers changing after a dependent's formula was

--- a/RaptorSheets.Core/Enums/Field.cs
+++ b/RaptorSheets.Core/Enums/Field.cs
@@ -35,5 +35,12 @@ public enum Field
     /// validation.
     /// </summary>
     [Description("userEnteredValue,note")]
-    USER_ENTERED_VALUE_AND_NOTE
+    USER_ENTERED_VALUE_AND_NOTE,
+
+    /// <summary>
+    /// Use this field to update only a cell's data validation rule, without touching value, format,
+    /// or note.
+    /// </summary>
+    [Description("dataValidation")]
+    DATA_VALIDATION
 }

--- a/RaptorSheets.Core/Helpers/ColumnInsertionHelper.cs
+++ b/RaptorSheets.Core/Helpers/ColumnInsertionHelper.cs
@@ -45,22 +45,18 @@ public static class ColumnInsertionHelper
                     column.ColumnIndex + 1,
                     inheritFromBefore: true));
 
-                var headerRow = new RowData
-                {
-                    Values = [BuildHeaderCell(column)]
-                };
-
-                requests.Add(GoogleRequestHelpers.GenerateUpdateCellsRequest(
-                    column.SheetId,
-                    rowIndex: 0,
-                    rows: [headerRow],
-                    startColumnIndex: column.ColumnIndex,
-                    fields: Field.USER_ENTERED_VALUE_AND_NOTE.GetDescription()));
+                requests.Add(BuildHeaderUpdateRequest(column));
 
                 var formatRequest = GoogleRequestHelpers.GenerateColumnFormatRequest(column.SheetId, column.ColumnIndex, column.Format, column.FormatPattern);
                 if (formatRequest != null)
                 {
                     requests.Add(formatRequest);
+                }
+
+                var validationRequest = GoogleRequestHelpers.GenerateColumnValidationRequest(column.SheetId, column.ColumnIndex, column.ValidationRule);
+                if (validationRequest != null)
+                {
+                    requests.Add(validationRequest);
                 }
             }
         }
@@ -98,6 +94,44 @@ public static class ColumnInsertionHelper
         }
 
         return cell;
+    }
+
+    /// <summary>
+    /// Builds the single-column, row-0-only UpdateCells request that writes a column's header cell
+    /// (name/formula/note, via <see cref="BuildHeaderCell"/>) using the narrow
+    /// <see cref="Field.USER_ENTERED_VALUE_AND_NOTE"/> field mask - touches nothing but that one
+    /// header cell, so it's safe to use both on a freshly-inserted (empty) column
+    /// (<see cref="BuildInsertRequests"/>) and, unlike that path's own <see cref="Field.USER_ENTERED_VALUE_AND_FORMAT"/>-
+    /// masked sheet-creation write, on an existing, already-populated column too - it never touches
+    /// format/validation/data rows (GitHub issue #53, gap 3: reapplying just a drifted column shares
+    /// this exact request shape with #53 gap 1's missing-column restoration).
+    /// </summary>
+    private static Request BuildHeaderUpdateRequest(ColumnInsertionInfo column)
+    {
+        var headerRow = new RowData
+        {
+            Values = [BuildHeaderCell(column)]
+        };
+
+        return GoogleRequestHelpers.GenerateUpdateCellsRequest(
+            column.SheetId,
+            rowIndex: 0,
+            rows: [headerRow],
+            startColumnIndex: column.ColumnIndex,
+            fields: Field.USER_ENTERED_VALUE_AND_NOTE.GetDescription());
+    }
+
+    /// <summary>
+    /// Builds one header-cell-fix request per entry in <paramref name="brokenColumns"/> - the
+    /// reapply counterpart to <see cref="BuildInsertRequests"/>'s insertion, for columns that
+    /// already exist but whose live Formula has drifted from canonical (GitHub issue #53, gap 3;
+    /// detection lives in <see cref="Managers.SheetManagerBase{TEntity}.DetectBrokenColumnsAsync"/>).
+    /// No InsertDimension (the column isn't missing) and no format/validation reapply (out of scope -
+    /// see DetectBrokenColumnsAsync's own doc comment for why only Formula is safely comparable).
+    /// </summary>
+    public static List<Request> BuildHeaderFixRequests(List<ColumnInsertionInfo> brokenColumns)
+    {
+        return brokenColumns.Select(BuildHeaderUpdateRequest).ToList();
     }
 
     /// <summary>

--- a/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
+++ b/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
@@ -390,6 +390,40 @@ public static class GoogleRequestHelpers
         return new Request { RepeatCell = repeatCellRequest };
     }
 
+    /// <summary>
+    /// Builds the RepeatCell request that reapplies a single column's data validation rule at
+    /// <paramref name="columnIndex"/> on <paramref name="sheetId"/>. Returns null when there's
+    /// nothing to reapply. Mirrors <see cref="GenerateColumnFormatRequest"/> - same narrow field
+    /// mask reasoning (<see cref="Field.DATA_VALIDATION"/> only, so a re-inserted column's
+    /// validation can be set without touching its value/format/note), same
+    /// <see cref="Helpers.ColumnInsertionHelper"/> call site (GitHub issue #103, the validation
+    /// counterpart to #53's Format restoration).
+    /// </summary>
+    public static Request? GenerateColumnValidationRequest(int sheetId, int columnIndex, DataValidationRule? validation)
+    {
+        if (validation == null)
+        {
+            return null;
+        }
+
+        var range = new GridRange
+        {
+            SheetId = sheetId,
+            StartColumnIndex = columnIndex,
+            EndColumnIndex = columnIndex + 1,
+            StartRowIndex = 1,
+        };
+
+        var repeatCellRequest = new RepeatCellRequest
+        {
+            Fields = Field.DATA_VALIDATION.GetDescription(),
+            Range = range,
+            Cell = new CellData { DataValidation = validation }
+        };
+
+        return new Request { RepeatCell = repeatCellRequest };
+    }
+
     public static Request GenerateSheetPropertes(SheetModel sheet)
     {
         var sheetRequest = new AddSheetRequest
@@ -540,13 +574,24 @@ public static class GoogleRequestHelpers
     }
 
     /// <summary>
-    /// Generic method to create update cell requests for any row entity type
+    /// Generic method to create update cell requests for any row entity type.
+    ///
+    /// The append/update split is keyed off <see cref="Property.MAX_ROW_VALUE"/> - the sheet's
+    /// *actual* last populated row (<see cref="SheetPropertyHelper.FindLastRowWithData"/>) - not
+    /// <see cref="Property.MAX_ROW"/> (the grid's row *capacity*, typically ~1000 by default).
+    /// <see cref="GenerateAppendCells"/> always lands right after the real data extent regardless of
+    /// RowId, so using the capacity as the threshold let a row classified as "update" (RowId within
+    /// capacity but past the real data) land on the exact same physical row an append in the same
+    /// batch was about to write - both requests go in one batch, append first then update, so the
+    /// update silently clobbered what append just wrote (GitHub issue #101, found stress-testing a
+    /// ~1,000-row write against a sheet with far fewer real rows). Keying off the actual data extent
+    /// instead means a row can only be "update" when something genuinely already exists there.
     /// </summary>
     public static IEnumerable<Request> CreateUpdateCellRequests<T>(List<T> entities, PropertyEntity? sheetProperties, Func<List<T>, IList<object>, IList<RowData>> mapToRowData)
         where T : SheetRowEntityBase
     {
         var headers = sheetProperties?.Attributes[Property.HEADERS.GetDescription()]?.Split(",").Cast<object>().ToList();
-        var maxRow = int.Parse(sheetProperties?.Attributes[Property.MAX_ROW.GetDescription()] ?? "0");
+        var maxRowValue = int.Parse(sheetProperties?.Attributes.GetValueOrDefault(Property.MAX_ROW_VALUE.GetDescription(), "0") ?? "0");
         int sheetId = int.TryParse(sheetProperties?.Id, out var id) ? id : 0;
 
         if (entities.Count == 0 || sheetProperties == null || headers?.Count == 0 || sheetId == 0)
@@ -556,14 +601,16 @@ public static class GoogleRequestHelpers
 
         var requests = new List<Request>();
 
-        var appendEntities = entities.Where(x => x.RowId > maxRow).ToList();
+        // Sorted by RowId so multiple appended rows land in the sheet in the same relative order as
+        // their assigned RowIds, rather than whatever order they happened to appear in `entities`.
+        var appendEntities = entities.Where(x => x.RowId > maxRowValue).OrderBy(x => x.RowId).ToList();
         if (appendEntities.Count > 0)
         {
             var appendData = mapToRowData(appendEntities, headers!);
             requests.Add(GenerateAppendCells(sheetId, appendData));
         }
 
-        var updateEntities = entities.Where(x => x.RowId <= maxRow).ToList();
+        var updateEntities = entities.Where(x => x.RowId <= maxRowValue).ToList();
         foreach (var entity in updateEntities)
         {
             var rowData = mapToRowData([entity], headers!);

--- a/RaptorSheets.Core/Helpers/HeaderHelpers.cs
+++ b/RaptorSheets.Core/Helpers/HeaderHelpers.cs
@@ -285,7 +285,8 @@ public static class HeaderHelpers
                     Format = sheetHeader.Format,
                     FormatPattern = sheetHeader.FormatPattern,
                     Note = sheetHeader.Note,
-                    Protect = sheetHeader.Protect
+                    Protect = sheetHeader.Protect,
+                    Validation = sheetHeader.Validation
                 });
 
                 messages.Add(MessageHelpers.CreateErrorMessage($"[{sheetColumn}]: Missing column [{sheetHeader.Name}] - can be inserted", MessageType.CHECK_SHEET));

--- a/RaptorSheets.Core/Managers/SheetManagerBase.cs
+++ b/RaptorSheets.Core/Managers/SheetManagerBase.cs
@@ -414,8 +414,6 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
             var needsTempSheet = NeedsTempSheet(existingSheetsToDelete, allTabNames);
             var tempSheetName = needsTempSheet ? TempSheetName : null;
 
-            var requests = BuildDeletionRequests(existingSheetsToDelete, tempSheetName);
-
             if (!string.IsNullOrEmpty(tempSheetName))
             {
                 entity.Messages.Add(MessageHelpers.CreateInfoMessage(
@@ -427,20 +425,16 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
                 $"Deleting {existingSheetsToDelete.Count} of {allTabNames.Count} sheets",
                 MessageType.DELETE_SHEET));
 
-            var batchRequest = new BatchUpdateSpreadsheetRequest { Requests = requests };
-            var result = await _googleSheetService.BatchUpdateSpreadsheet(batchRequest, cancellationToken);
+            var protectedSheets = existingSheetsToDelete.Where(IsProtectedSheet).ToList();
 
-            if (result != null)
+            if (protectedSheets.Count <= 1)
             {
-                entity.Messages.Add(MessageHelpers.CreateInfoMessage(
-                    "Sheet deletion completed successfully",
-                    MessageType.DELETE_SHEET));
+                // Common case - unchanged from before #102: everything in one batch call.
+                await ExecuteDeleteBatchAsync(existingSheetsToDelete, tempSheetName, entity, cancellationToken);
             }
             else
             {
-                entity.Messages.Add(MessageHelpers.CreateErrorMessage(
-                    "Sheet deletion failed - unable to execute batch request",
-                    MessageType.DELETE_SHEET));
+                await ExecuteSplitDeleteAsync(existingSheetsToDelete, protectedSheets, tempSheetName, entity, cancellationToken);
             }
         }
         catch (Exception ex)
@@ -451,6 +445,64 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
         }
 
         return entity;
+    }
+
+    private bool IsProtectedSheet(PropertyEntity property)
+    {
+        return _registry.GetSheetLayout(property.Name)?.ProtectSheet ?? false;
+    }
+
+    /// <summary>
+    /// Builds and sends a single delete batch for <paramref name="sheetsToDelete"/> (optionally
+    /// preceded by a temp-sheet-creation request), reporting success/failure onto
+    /// <paramref name="entity"/>. Both <see cref="DeleteSheets"/> paths funnel through this - the
+    /// unsplit common case calls it once with everything; the split path (#102) calls it once per
+    /// group/sheet, so the exact same success/failure message text can appear more than once when
+    /// split, one per call.
+    /// </summary>
+    private async Task ExecuteDeleteBatchAsync(List<PropertyEntity> sheetsToDelete, string? tempSheetName, TEntity entity, CancellationToken cancellationToken)
+    {
+        var requests = BuildDeletionRequests(sheetsToDelete, tempSheetName);
+        var batchRequest = new BatchUpdateSpreadsheetRequest { Requests = requests };
+        var result = await _googleSheetService.BatchUpdateSpreadsheet(batchRequest, cancellationToken);
+
+        if (result != null)
+        {
+            entity.Messages.Add(MessageHelpers.CreateInfoMessage(
+                "Sheet deletion completed successfully",
+                MessageType.DELETE_SHEET));
+        }
+        else
+        {
+            entity.Messages.Add(MessageHelpers.CreateErrorMessage(
+                "Sheet deletion failed - unable to execute batch request",
+                MessageType.DELETE_SHEET));
+        }
+    }
+
+    /// <summary>
+    /// Google 500s deleting 2+ protected sheets in a single batch (GitHub issue #102 - reproduced
+    /// 5/5 live against Stock's Accounts/Tickers, both <see cref="Models.Google.SheetModel.ProtectSheet"/>);
+    /// deleting the same sheets one at a time works reliably. Splits into one call for every
+    /// unprotected sheet (plus the temp-sheet safety net, if needed - it must exist before any
+    /// sheet that would otherwise be "the last one" is deleted, so it goes in this first call), then
+    /// one call per protected sheet. No longer atomic - each call's own success/failure is reported
+    /// via <see cref="ExecuteDeleteBatchAsync"/> rather than one combined pass/fail, since a caller
+    /// retrying "all at once" after a partial failure would just hit the same 500 again.
+    /// </summary>
+    private async Task ExecuteSplitDeleteAsync(List<PropertyEntity> sheetsToDelete, List<PropertyEntity> protectedSheets, string? tempSheetName, TEntity entity, CancellationToken cancellationToken)
+    {
+        var unprotectedSheets = sheetsToDelete.Except(protectedSheets).ToList();
+
+        if (unprotectedSheets.Count > 0 || !string.IsNullOrEmpty(tempSheetName))
+        {
+            await ExecuteDeleteBatchAsync(unprotectedSheets, tempSheetName, entity, cancellationToken);
+        }
+
+        foreach (var protectedSheet in protectedSheets)
+        {
+            await ExecuteDeleteBatchAsync([protectedSheet], null, entity, cancellationToken);
+        }
     }
 
     private async Task<List<PropertyEntity>> GetExistingSheetsToDelete(List<string> sheets, TEntity entity, CancellationToken cancellationToken = default)
@@ -960,12 +1012,40 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
     #region Header Management / Column Healing
 
     /// <summary>
+    /// Resolves a re-inserted column's raw <see cref="ColumnInsertionInfo.Validation"/> name into a
+    /// concrete <see cref="DataValidationRule"/> - like the header's other restored properties
+    /// (Formula/Format/Note/Protect - see #53), except validation resolution needs a domain's own
+    /// <c>Validation</c> enum and range-sheet mapping, which isn't available in Core. Defaults to a
+    /// no-op so no domain is forced to change; domains that want self-heal to restore dropdowns
+    /// override this, typically delegating straight to their existing <c>GetDataValidation</c>
+    /// resolver (GitHub issue #103).
+    /// </summary>
+    protected virtual DataValidationRule? GetDataValidation(ColumnInsertionInfo column) => null;
+
+    /// <summary>
+    /// Fills in <see cref="ColumnInsertionInfo.ValidationRule"/> for every column about to be
+    /// inserted, via <see cref="GetDataValidation"/> - same "detected with a placeholder, filled in
+    /// by the caller before acting on it" convention already used for <see cref="ColumnInsertionInfo.SheetId"/>.
+    /// </summary>
+    private void ResolveValidationRules(Dictionary<string, List<ColumnInsertionInfo>> missingColumns)
+    {
+        foreach (var columns in missingColumns.Values)
+        {
+            foreach (var column in columns)
+            {
+                column.ValidationRule = GetDataValidation(column);
+            }
+        }
+    }
+
+    /// <summary>
     /// Physically inserts columns detected as missing (via a domain's static CheckSheetHeaders
     /// out-overload or via <see cref="SheetRegistry{TEntity}.DetectMissingColumns"/>) at their
     /// expected position, and writes the header text into each newly-inserted column.
     /// </summary>
     public async Task<TEntity> InsertMissingColumns(Dictionary<string, List<ColumnInsertionInfo>> missingColumns, CancellationToken cancellationToken = default)
     {
+        ResolveValidationRules(missingColumns);
         return await ColumnInsertionHelper.InsertMissingColumnsAsync<TEntity>(_googleSheetService, missingColumns, cancellationToken: cancellationToken);
     }
 
@@ -1037,6 +1117,7 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
         List<MessageEntity> messages,
         CancellationToken cancellationToken)
     {
+        ResolveValidationRules(missingColumns);
         var dependentRefreshRequests = await BuildDependentRefreshRequestsAsync(missingColumns.Keys, spreadsheetInfo, cancellationToken);
         var insertResult = await ColumnInsertionHelper.InsertMissingColumnsAsync<TEntity>(_googleSheetService, missingColumns, dependentRefreshRequests, cancellationToken);
         messages.AddRange(insertResult.Messages);
@@ -1179,6 +1260,108 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
         var dependents = _registry.GetDependents(changedSheetNames);
 
         return dependents.Count == 0 ? [] : await BuildHeaderFormulaRequestsAsync(dependents, spreadsheetInfo, cancellationToken);
+    }
+
+    #endregion
+
+    #region Broken Column Detection / Reapply
+
+    /// <summary>
+    /// Detects columns that already exist (by name, in both the canonical layout and the live
+    /// sheet) but whose live Formula has silently drifted from canonical - e.g. a formula manually
+    /// overwritten or a spilling QUERY that broke (GitHub issue #53, gap 2). Distinct from missing-
+    /// column self-heal (<see cref="AutoHealMissingColumnsAsync(BatchGetValuesByDataFilterResponse, Spreadsheet?, List{MessageEntity}, CancellationToken)"/>) -
+    /// a column absent from the live sheet entirely is that path's job, not this one's; this only
+    /// ever looks at columns present under the same name on both sides.
+    ///
+    /// Opt-in only - never called from a read path, matching [[raptorsheets-design-philosophy]]'s
+    /// "reads never silently mutate" precedent; a caller explicitly requests this check.
+    ///
+    /// Formula-only: unlike Formula, a live-read <see cref="Models.Google.SheetCellModel.Validation"/>
+    /// is the raw condition off the sheet (e.g. "ONE_OF_RANGE:Names!A2:A") while the canonical
+    /// layout's is a domain enum token (e.g. "RANGE_SERVICE") - see
+    /// <see cref="SheetStructureHelper"/>'s own type-level doc comment - so Core has no reliable way
+    /// to compare them; a live-vs-canonical Validation comparison would mismatch even when correct.
+    /// Format is similarly left out (not needed by the issue this closes - reapplying a whole
+    /// sheet's column formats already exists via <see cref="ReapplyFormatting(List{string}, FormattingOptionsEntity?, CancellationToken)"/>).
+    /// </summary>
+    public async Task<List<ColumnInsertionInfo>> DetectBrokenColumnsAsync(string sheet, CancellationToken cancellationToken = default)
+    {
+        var canonical = _registry.GetSheetLayout(sheet);
+
+        if (canonical == null)
+        {
+            return [];
+        }
+
+        var live = await GetLiveSheetStructure(sheet, cancellationToken);
+
+        if (live == null)
+        {
+            return [];
+        }
+
+        // A HideHeaderName column never has its own header cell written (its text spills from an
+        // earlier header's QUERY formula instead - see SheetHelpers' use of the flag), so the live
+        // read never has a FormattedValue for it and it simply won't be found below - no separate
+        // exclusion needed here.
+        var liveHeadersByName = live.Headers.ToDictionary(h => h.Name, StringComparer.OrdinalIgnoreCase);
+        var broken = new List<ColumnInsertionInfo>();
+
+        foreach (var canonicalHeader in canonical.Headers)
+        {
+            if (!liveHeadersByName.TryGetValue(canonicalHeader.Name, out var liveHeader))
+            {
+                continue;
+            }
+
+            if (canonicalHeader.Formula == liveHeader.Formula)
+            {
+                continue;
+            }
+
+            broken.Add(new ColumnInsertionInfo
+            {
+                SheetName = sheet,
+                SheetId = live.Id,
+                ColumnIndex = liveHeader.Index,
+                ColumnName = canonicalHeader.Name,
+                ColumnLetter = liveHeader.Column,
+                Formula = canonicalHeader.Formula,
+                Note = canonicalHeader.Note,
+                Protect = canonicalHeader.Protect
+            });
+        }
+
+        return broken;
+    }
+
+    /// <summary>
+    /// Rewrites just the header cell (name/formula/note) of every column in
+    /// <paramref name="brokenColumns"/> with its canonical Formula - the reapply counterpart to
+    /// <see cref="DetectBrokenColumnsAsync"/>, sharing <see cref="ColumnInsertionHelper"/>'s
+    /// header-cell-write request with missing-column restoration (#53, gap 3). Safe on an existing,
+    /// populated column: the narrow field mask only ever touches that one header cell, never the
+    /// data rows beneath it.
+    /// </summary>
+    public async Task<TEntity> ReapplyColumnFormulas(string sheet, List<ColumnInsertionInfo> brokenColumns, CancellationToken cancellationToken = default)
+    {
+        var entity = new TEntity();
+
+        if (brokenColumns == null || brokenColumns.Count == 0)
+        {
+            entity.Messages.Add(MessageHelpers.CreateInfoMessage("No broken columns to reapply", MessageType.GENERAL));
+            return entity;
+        }
+
+        var requests = ColumnInsertionHelper.BuildHeaderFixRequests(brokenColumns);
+        var response = await _googleSheetService.BatchUpdateSpreadsheet(new BatchUpdateSpreadsheetRequest { Requests = requests }, cancellationToken);
+
+        entity.Messages.Add(response != null
+            ? MessageHelpers.CreateInfoMessage($"Reapplied formula for {brokenColumns.Count} column(s) on {sheet}", MessageType.GENERAL)
+            : MessageHelpers.CreateErrorMessage($"Failed to reapply column formulas on {sheet}", MessageType.GENERAL));
+
+        return entity;
     }
 
     #endregion

--- a/RaptorSheets.Core/Managers/SheetManagerBase.cs
+++ b/RaptorSheets.Core/Managers/SheetManagerBase.cs
@@ -1033,7 +1033,11 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
         {
             foreach (var column in columns)
             {
-                column.ValidationRule = GetDataValidation(column);
+                // Only fill in when unset. A caller of the public insertion API may have already
+                // supplied a resolved rule directly, bypassing the resolution hook below - always
+                // re-resolving would silently wipe that out with a null whenever the hook doesn't
+                // recognize the column, e.g. the base class's no-op default.
+                column.ValidationRule ??= GetDataValidation(column);
             }
         }
     }
@@ -1305,7 +1309,16 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
         // earlier header's QUERY formula instead - see SheetHelpers' use of the flag), so the live
         // read never has a FormattedValue for it and it simply won't be found below - no separate
         // exclusion needed here.
-        var liveHeadersByName = live.Headers.ToDictionary(h => h.Name, StringComparer.OrdinalIgnoreCase);
+        //
+        // Grouped rather than a plain ToDictionary: a live sheet can genuinely have blank or
+        // duplicate header names (a user clearing/renaming cells by hand), and this method's whole
+        // job is tolerating real-world sheet drift - a ToDictionary key collision would throw and
+        // abort detection entirely instead of just skipping the ambiguous column. First occurrence
+        // wins for a duplicate name.
+        var liveHeadersByName = live.Headers
+            .Where(h => !string.IsNullOrEmpty(h.Name))
+            .GroupBy(h => h.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
         var broken = new List<ColumnInsertionInfo>();
 
         foreach (var canonicalHeader in canonical.Headers)

--- a/RaptorSheets.Core/Models/ColumnInsertionInfo.cs
+++ b/RaptorSheets.Core/Models/ColumnInsertionInfo.cs
@@ -1,3 +1,4 @@
+using Google.Apis.Sheets.v4.Data;
 using RaptorSheets.Core.Enums;
 
 namespace RaptorSheets.Core.Models;
@@ -55,4 +56,21 @@ public class ColumnInsertionInfo
     /// convention used at sheet-creation time).
     /// </summary>
     public bool Protect { get; set; }
+
+    /// <summary>
+    /// The canonical column's raw validation name (e.g. "RANGE_SERVICE"), if any - each domain's own
+    /// <c>Validation</c> enum member name, exactly as stored on <see cref="Models.Google.SheetCellModel.Validation"/>.
+    /// Resolving this into a concrete <see cref="ValidationRule"/> is domain-specific (see
+    /// <see cref="Managers.SheetManagerBase{TEntity}.GetDataValidation(ColumnInsertionInfo)"/>), so it's
+    /// carried here only as the raw input to that resolution (GitHub issue #103).
+    /// </summary>
+    public string? Validation { get; set; }
+
+    /// <summary>
+    /// The resolved data validation rule for this column, if any. Left null when the column is
+    /// detected - like <see cref="SheetId"/>, it's filled in afterward by
+    /// <see cref="Managers.SheetManagerBase{TEntity}"/> via its <c>GetDataValidation</c> hook, since
+    /// resolving <see cref="Validation"/> requires domain-specific knowledge Core doesn't have.
+    /// </summary>
+    public DataValidationRule? ValidationRule { get; set; }
 }

--- a/RaptorSheets.Gig.Tests/Unit/Helpers/GigRequestHelpersTests.cs
+++ b/RaptorSheets.Gig.Tests/Unit/Helpers/GigRequestHelpersTests.cs
@@ -231,14 +231,15 @@ public class GigRequestHelpersTests
     public void CreateUpdateCellTripRequests_WithUpdateTrips_ShouldReturnUpdateRequests()
     {
         // Arrange
-        var trips = new List<TripEntity> { new() { RowId = 5 } }; // RowId <= maxRow
-        var sheetProperties = new PropertyEntity 
-        { 
+        var trips = new List<TripEntity> { new() { RowId = 5 } }; // RowId <= maxRowValue
+        var sheetProperties = new PropertyEntity
+        {
             Id = "1",
             Attributes = new Dictionary<string, string>
             {
                 { Property.HEADERS.GetDescription(), "Date,Number,Service" },
-                { Property.MAX_ROW.GetDescription(), "10" }
+                { Property.MAX_ROW.GetDescription(), "10" },
+                { Property.MAX_ROW_VALUE.GetDescription(), "5" }
             }
         };
 
@@ -257,18 +258,19 @@ public class GigRequestHelpersTests
     public void CreateUpdateCellTripRequests_WithMixedTrips_ShouldReturnBothTypes()
     {
         // Arrange
-        var trips = new List<TripEntity> 
-        { 
-            new() { RowId = 5 },  // Update (RowId <= maxRow)
-            new() { RowId = 15 }  // Append (RowId > maxRow)
+        var trips = new List<TripEntity>
+        {
+            new() { RowId = 5 },  // Update (RowId <= maxRowValue)
+            new() { RowId = 15 }  // Append (RowId > maxRowValue)
         };
-        var sheetProperties = new PropertyEntity 
-        { 
+        var sheetProperties = new PropertyEntity
+        {
             Id = "1",
             Attributes = new Dictionary<string, string>
             {
                 { Property.HEADERS.GetDescription(), "Date,Number,Service" },
-                { Property.MAX_ROW.GetDescription(), "10" }
+                { Property.MAX_ROW.GetDescription(), "10" },
+                { Property.MAX_ROW_VALUE.GetDescription(), "5" }
             }
         };
 
@@ -280,6 +282,43 @@ public class GigRequestHelpersTests
         Assert.Equal(2, result.Count);
         Assert.Contains(result, r => r.AppendCells != null);  // One append request
         Assert.Contains(result, r => r.UpdateCells != null);  // One update request
+    }
+
+    [Fact]
+    public void CreateUpdateCellTripRequests_WithRowIdWithinCapacityButPastRealData_ShouldAppendNotCollide()
+    {
+        // #101 regression: RowId=3 sits well within the sheet's grid capacity (MAX_ROW=1000, the
+        // default) but past its actual data extent (MAX_ROW_VALUE=1 - only the header row is real).
+        // Before the fix, classifying by capacity treated RowId=3 as "update at explicit index 2" -
+        // the exact same physical row AppendCells lands the RowId=1001 entity on, since Append always
+        // writes right after the real data extent regardless of RowId. Both requests landed in the
+        // same batch (append first, then update), so the update silently clobbered the appended row.
+        // The fix means both entities are recognized as append-eligible and folded into one
+        // AppendCells request - no UpdateCells request should exist at all.
+        var trips = new List<TripEntity>
+        {
+            new() { RowId = 1001 },
+            new() { RowId = 3 }
+        };
+        var sheetProperties = new PropertyEntity
+        {
+            Id = "1",
+            Attributes = new Dictionary<string, string>
+            {
+                { Property.HEADERS.GetDescription(), "Date,Number,Service" },
+                { Property.MAX_ROW.GetDescription(), "1000" },
+                { Property.MAX_ROW_VALUE.GetDescription(), "1" }
+            }
+        };
+
+        // Act
+        var result = GigRequestHelpers.CreateUpdateCellTripRequests(trips, sheetProperties).ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.NotNull(result[0].AppendCells);
+        Assert.DoesNotContain(result, r => r.UpdateCells != null);
+        Assert.Equal(2, result[0].AppendCells.Rows.Count);
     }
 
     #endregion
@@ -360,14 +399,15 @@ public class GigRequestHelpersTests
     public void CreateUpdateCellShiftRequests_WithUpdateShifts_ShouldReturnUpdateRequests()
     {
         // Arrange
-        var shifts = new List<ShiftEntity> { new() { RowId = 5 } }; // RowId <= maxRow
-        var sheetProperties = new PropertyEntity 
-        { 
+        var shifts = new List<ShiftEntity> { new() { RowId = 5 } }; // RowId <= maxRowValue
+        var sheetProperties = new PropertyEntity
+        {
             Id = "1",
             Attributes = new Dictionary<string, string>
             {
                 { Property.HEADERS.GetDescription(), "Date,Number,Service" },
-                { Property.MAX_ROW.GetDescription(), "10" }
+                { Property.MAX_ROW.GetDescription(), "10" },
+                { Property.MAX_ROW_VALUE.GetDescription(), "5" }
             }
         };
 
@@ -459,14 +499,15 @@ public class GigRequestHelpersTests
     public void CreateUpdateCellSetupRequests_WithUpdateSetup_ShouldReturnUpdateRequests()
     {
         // Arrange
-        var setup = new List<SetupEntity> { new() { RowId = 5 } }; // RowId <= maxRow
-        var sheetProperties = new PropertyEntity 
-        { 
+        var setup = new List<SetupEntity> { new() { RowId = 5 } }; // RowId <= maxRowValue
+        var sheetProperties = new PropertyEntity
+        {
             Id = "1",
             Attributes = new Dictionary<string, string>
             {
                 { Property.HEADERS.GetDescription(), "Name,Value,Description" },
-                { Property.MAX_ROW.GetDescription(), "10" }
+                { Property.MAX_ROW.GetDescription(), "10" },
+                { Property.MAX_ROW_VALUE.GetDescription(), "5" }
             }
         };
 
@@ -495,13 +536,14 @@ public class GigRequestHelpersTests
             new() { RowId = 15, Action = ActionType.DELETE.GetDescription() } // Delete trip
         };
         
-        var sheetProperties = new PropertyEntity 
-        { 
+        var sheetProperties = new PropertyEntity
+        {
             Id = "1",
             Attributes = new Dictionary<string, string>
             {
                 { Property.HEADERS.GetDescription(), "Date,Service,Pay,Tips" },
-                { Property.MAX_ROW.GetDescription(), "8" }
+                { Property.MAX_ROW.GetDescription(), "8" },
+                { Property.MAX_ROW_VALUE.GetDescription(), "5" }
             }
         };
 
@@ -511,11 +553,11 @@ public class GigRequestHelpersTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(3, result.Count); // Should have append, update, and delete requests
-        
-        // Should have one append request (RowId 10 > maxRow 8)
+
+        // Should have one append request (RowId 10 > maxRowValue 5)
         Assert.Single(result, r => r.AppendCells != null);
-        
-        // Should have one update request (RowId 5 <= maxRow 8) 
+
+        // Should have one update request (RowId 5 <= maxRowValue 5)
         Assert.Single(result, r => r.UpdateCells != null);
         
         // Should have one delete request (RowId 15 marked for deletion)

--- a/RaptorSheets.Gig.Tests/Unit/Managers/DetectAndReapplyBrokenColumnsBehaviorTests.cs
+++ b/RaptorSheets.Gig.Tests/Unit/Managers/DetectAndReapplyBrokenColumnsBehaviorTests.cs
@@ -1,0 +1,74 @@
+using Google.Apis.Sheets.v4.Data;
+using Moq;
+using RaptorSheets.Core.Services;
+using RaptorSheets.Gig.Managers;
+using Xunit;
+
+namespace RaptorSheets.Gig.Tests.Unit.Managers;
+
+/// <summary>
+/// Covers Gig's wiring of #53 gaps 2/3: detecting a column whose live Formula has drifted from
+/// canonical, then reapplying it. The underlying logic (SheetManagerBase.DetectBrokenColumnsAsync/
+/// ReapplyColumnFormulas, ColumnInsertionHelper.BuildHeaderFixRequests) has its own dedicated tests
+/// in RaptorSheets.Core.Tests - this just confirms the two chain together correctly end to end
+/// against a real Gig sheet layout.
+/// </summary>
+public class DetectAndReapplyBrokenColumnsBehaviorTests
+{
+    [Fact]
+    public async Task DetectThenReapply_WithDriftedFormulaColumn_FixesItInOneRoundTrip()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        var manager = new SheetManager(mockService.Object);
+
+        // Trips has several ArrayFormula-driven columns (see TripSheet.cs) - use the real canonical
+        // model rather than hand-rolled formula text, so this test stays correct as those formulas
+        // evolve.
+        var canonical = manager.GetSheetLayout("Trips")!;
+        var brokenHeader = canonical.Headers.First(h => !string.IsNullOrEmpty(h.Formula));
+
+        // Every other header's live formula must match its canonical one exactly (several Trip
+        // columns have formulas) - only brokenHeader should end up flagged.
+        static ExtendedValue? LiveFormulaValue(string? formula) => string.IsNullOrEmpty(formula) ? null : new ExtendedValue { FormulaValue = formula };
+
+        var liveHeaders = canonical.Headers
+            .Select(h => new CellData
+            {
+                FormattedValue = h.Name,
+                UserEnteredValue = h.Name == brokenHeader.Name ? LiveFormulaValue("=BROKEN") : LiveFormulaValue(h.Formula)
+            })
+            .ToList();
+
+        var spreadsheet = new Spreadsheet
+        {
+            Sheets = new List<Sheet>
+            {
+                new()
+                {
+                    Properties = new SheetProperties { Title = "Trips", SheetId = 7 },
+                    Data = new List<GridData> { new() { RowData = new List<RowData> { new() { Values = liveHeaders } } } }
+                }
+            }
+        };
+
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+        BatchUpdateSpreadsheetRequest? capturedRequest = null;
+        mockService.Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => capturedRequest = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        // Act
+        var broken = await manager.DetectBrokenColumnsAsync("Trips");
+        var result = await manager.ReapplyColumnFormulas("Trips", broken);
+
+        // Assert
+        var fixedColumn = Assert.Single(broken);
+        Assert.Equal(brokenHeader.Name, fixedColumn.ColumnName);
+        Assert.Equal(brokenHeader.Formula, fixedColumn.Formula); // canonical, not the "=BROKEN" live one
+
+        Assert.NotNull(capturedRequest);
+        var updateRequest = capturedRequest.Requests.Single();
+        Assert.Equal(brokenHeader.Formula, updateRequest.UpdateCells.Rows[0].Values[0].UserEnteredValue.FormulaValue);
+        Assert.Contains(result.Messages, m => m.Message.Contains("Reapplied formula for 1 column"));
+    }
+}

--- a/RaptorSheets.Gig.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
+++ b/RaptorSheets.Gig.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
@@ -91,4 +91,32 @@ public class InsertMissingColumnsBehaviorTests
         Assert.Contains(capturedRequest.Requests, r => r.InsertDimension != null && r.InsertDimension.Range.SheetId == 7);
         Assert.Contains(result.Messages, m => m.Message.Contains("Successfully inserted 1 missing column(s)"));
     }
+
+    [Fact]
+    public async Task InsertMissingColumns_WithRawValidationName_ResolvesAndAppliesDataValidationRule()
+    {
+        // #103: a re-inserted dropdown column (e.g. Trip Service) must get its validation rule
+        // back - the raw Validation name is resolved via SheetManager's GetDataValidation override.
+        var mockService = new Mock<IGoogleSheetService>();
+        BatchUpdateSpreadsheetRequest? capturedRequest = null;
+        mockService
+            .Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => capturedRequest = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new SheetManager(mockService.Object);
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Trips"] = [new ColumnInsertionInfo { SheetName = "Trips", SheetId = 7, ColumnIndex = 3, ColumnName = "Cash", ColumnLetter = "D", Validation = "BOOLEAN" }]
+        };
+
+        // Act
+        await manager.InsertMissingColumns(missingColumns);
+
+        // Assert
+        Assert.NotNull(capturedRequest);
+        var validationRequest = capturedRequest.Requests.Single(r => r.RepeatCell != null);
+        Assert.Equal("dataValidation", validationRequest.RepeatCell.Fields);
+        Assert.Equal("BOOLEAN", validationRequest.RepeatCell.Cell.DataValidation.Condition.Type);
+    }
 }

--- a/RaptorSheets.Gig/Managers/SheetManager.cs
+++ b/RaptorSheets.Gig/Managers/SheetManager.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using RaptorSheets.Core.Constants;
 using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Enums;
+using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Managers;
 using RaptorSheets.Core.Models;
@@ -62,6 +63,22 @@ public class SheetManager : SheetManagerBase<SheetEntity>, ISheetManager
     protected override BatchUpdateSpreadsheetRequest GenerateSheetsRequest(List<string> sheetNames)
     {
         return GenerateSheetsHelpers.Generate(sheetNames);
+    }
+
+    /// <summary>
+    /// Resolves a self-healed column's raw Validation name (e.g. "RANGE_SERVICE") into a concrete
+    /// data validation rule, restoring dropdowns on a re-inserted column (GitHub issue #103) the
+    /// same way <see cref="GenerateSheetsHelpers"/> already does at sheet-creation time.
+    /// </summary>
+    protected override DataValidationRule? GetDataValidation(ColumnInsertionInfo column)
+    {
+        if (string.IsNullOrEmpty(column.Validation))
+        {
+            return null;
+        }
+
+        var columnRange = $"{column.ColumnLetter}2:{column.ColumnLetter}";
+        return GigSheetHelpers.GetDataValidation(column.Validation.GetValueFromName<Validation>(), columnRange);
     }
 
     #endregion

--- a/RaptorSheets.Home.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
+++ b/RaptorSheets.Home.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
@@ -1,0 +1,43 @@
+using Google.Apis.Sheets.v4.Data;
+using Moq;
+using RaptorSheets.Core.Models;
+using RaptorSheets.Core.Services;
+using RaptorSheets.Home.Managers;
+using Xunit;
+
+namespace RaptorSheets.Home.Tests.Unit.Managers;
+
+/// <summary>
+/// Covers Home's wiring of the self-heal column-validation restoration (GitHub issue #103). The
+/// shared insertion logic (RaptorSheets.Core.Helpers.ColumnInsertionHelper) has its own dedicated
+/// tests in RaptorSheets.Core.Tests - this just confirms Home's SheetManager.GetDataValidation
+/// override actually resolves and wires through.
+/// </summary>
+public class InsertMissingColumnsBehaviorTests
+{
+    [Fact]
+    public async Task InsertMissingColumns_WithRawValidationName_ResolvesAndAppliesDataValidationRule()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        BatchUpdateSpreadsheetRequest? capturedRequest = null;
+        mockService
+            .Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => capturedRequest = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new SheetManager(mockService.Object);
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Appliances"] = [new ColumnInsertionInfo { SheetName = "Appliances", SheetId = 3, ColumnIndex = 1, ColumnName = "Active", ColumnLetter = "B", Validation = "BOOLEAN" }]
+        };
+
+        // Act
+        await manager.InsertMissingColumns(missingColumns);
+
+        // Assert
+        Assert.NotNull(capturedRequest);
+        var validationRequest = capturedRequest.Requests.Single(r => r.RepeatCell != null);
+        Assert.Equal("dataValidation", validationRequest.RepeatCell.Fields);
+        Assert.Equal("BOOLEAN", validationRequest.RepeatCell.Cell.DataValidation.Condition.Type);
+    }
+}

--- a/RaptorSheets.Home/Managers/SheetManager.cs
+++ b/RaptorSheets.Home/Managers/SheetManager.cs
@@ -2,12 +2,14 @@ using Google.Apis.Sheets.v4.Data;
 using Microsoft.Extensions.Logging;
 using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Enums;
+using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Managers;
 using RaptorSheets.Core.Models;
 using RaptorSheets.Core.Models.Google;
 using RaptorSheets.Home.Constants;
 using RaptorSheets.Home.Entities;
+using RaptorSheets.Home.Enums;
 using RaptorSheets.Home.Helpers;
 
 namespace RaptorSheets.Home.Managers;
@@ -55,6 +57,22 @@ public class SheetManager : SheetManagerBase<SheetEntity>, ISheetManager
     protected override BatchUpdateSpreadsheetRequest GenerateSheetsRequest(List<string> sheetNames)
     {
         return GenerateSheetsHelpers.Generate(sheetNames);
+    }
+
+    /// <summary>
+    /// Resolves a self-healed column's raw Validation name into a concrete data validation rule,
+    /// restoring dropdowns on a re-inserted column (GitHub issue #103) the same way
+    /// <see cref="GenerateSheetsHelpers"/> already does at sheet-creation time.
+    /// </summary>
+    protected override DataValidationRule? GetDataValidation(ColumnInsertionInfo column)
+    {
+        if (string.IsNullOrEmpty(column.Validation))
+        {
+            return null;
+        }
+
+        var columnRange = $"{column.ColumnLetter}2:{column.ColumnLetter}";
+        return HomeSheetHelpers.GetDataValidation(column.Validation.GetValueFromName<Validation>(), columnRange);
     }
 
     #endregion

--- a/RaptorSheets.Job.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
+++ b/RaptorSheets.Job.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
@@ -1,0 +1,45 @@
+using Google.Apis.Sheets.v4.Data;
+using Moq;
+using RaptorSheets.Core.Models;
+using RaptorSheets.Core.Services;
+using RaptorSheets.Job.Managers;
+using Xunit;
+
+namespace RaptorSheets.Job.Tests.Unit.Managers;
+
+/// <summary>
+/// Covers Job's wiring of the self-heal column-validation restoration (GitHub issue #103). Job
+/// stores the actual A1 range directly as the raw validation value (no enum), so this also
+/// confirms SheetManager.GetDataValidation passes it straight through to JobSheetHelpers rather
+/// than trying to parse it as an enum name. The shared insertion logic
+/// (RaptorSheets.Core.Helpers.ColumnInsertionHelper) has its own dedicated tests in
+/// RaptorSheets.Core.Tests.
+/// </summary>
+public class InsertMissingColumnsBehaviorTests
+{
+    [Fact]
+    public async Task InsertMissingColumns_WithRawValidationRange_ResolvesAndAppliesDataValidationRule()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        BatchUpdateSpreadsheetRequest? capturedRequest = null;
+        mockService
+            .Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => capturedRequest = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new SheetManager(mockService.Object);
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Applications"] = [new ColumnInsertionInfo { SheetName = "Applications", SheetId = 4, ColumnIndex = 1, ColumnName = "Company", Validation = "Companies!$A$2:$A" }]
+        };
+
+        // Act
+        await manager.InsertMissingColumns(missingColumns);
+
+        // Assert
+        Assert.NotNull(capturedRequest);
+        var validationRequest = capturedRequest.Requests.Single(r => r.RepeatCell != null);
+        Assert.Equal("dataValidation", validationRequest.RepeatCell.Fields);
+        Assert.Equal("ONE_OF_RANGE", validationRequest.RepeatCell.Cell.DataValidation.Condition.Type);
+    }
+}

--- a/RaptorSheets.Job/Managers/SheetManager.cs
+++ b/RaptorSheets.Job/Managers/SheetManager.cs
@@ -57,6 +57,17 @@ public class SheetManager : SheetManagerBase<SheetEntity>, ISheetManager
         return GenerateSheetsHelpers.Generate(sheetNames);
     }
 
+    /// <summary>
+    /// Resolves a self-healed column's raw Validation value into a concrete data validation rule,
+    /// restoring dropdowns on a re-inserted column (GitHub issue #103). Job stores the actual A1
+    /// range directly as the validation value, so no enum conversion is needed here - see
+    /// <see cref="JobSheetHelpers.GetDataValidation(string?)"/>.
+    /// </summary>
+    protected override DataValidationRule? GetDataValidation(ColumnInsertionInfo column)
+    {
+        return string.IsNullOrEmpty(column.Validation) ? null : JobSheetHelpers.GetDataValidation(column.Validation);
+    }
+
     #endregion
 
     #region Update Operations

--- a/RaptorSheets.Stock.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
+++ b/RaptorSheets.Stock.Tests/Unit/Managers/InsertMissingColumnsBehaviorTests.cs
@@ -82,4 +82,32 @@ public class InsertMissingColumnsBehaviorTests
         // Assert
         Assert.Contains(result.Messages, m => m.Message.Contains("Successfully inserted 1 missing column(s)"));
     }
+
+    [Fact]
+    public async Task InsertMissingColumns_WithRawValidationName_ResolvesAndAppliesDataValidationRule()
+    {
+        // #103: a re-inserted dropdown column's raw Validation name must be resolved via
+        // SheetManager's GetDataValidation override and applied as a real DataValidationRule.
+        var mockService = new Mock<IGoogleSheetService>();
+        BatchUpdateSpreadsheetRequest? capturedRequest = null;
+        mockService
+            .Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => capturedRequest = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new SheetManager(mockService.Object);
+        var missingColumns = new Dictionary<string, List<ColumnInsertionInfo>>
+        {
+            ["Stocks"] = [new ColumnInsertionInfo { SheetName = "Stocks", SheetId = 3, ColumnIndex = 1, ColumnName = "Active", Validation = "BOOLEAN" }]
+        };
+
+        // Act
+        await manager.InsertMissingColumns(missingColumns);
+
+        // Assert
+        Assert.NotNull(capturedRequest);
+        var validationRequest = capturedRequest.Requests.Single(r => r.RepeatCell != null);
+        Assert.Equal("dataValidation", validationRequest.RepeatCell.Fields);
+        Assert.Equal("BOOLEAN", validationRequest.RepeatCell.Cell.DataValidation.Condition.Type);
+    }
 }

--- a/RaptorSheets.Stock/Managers/SheetManager.cs
+++ b/RaptorSheets.Stock/Managers/SheetManager.cs
@@ -9,6 +9,7 @@ using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Managers;
 using RaptorSheets.Core.Models;
 using RaptorSheets.Stock.Entities;
+using RaptorSheets.Stock.Enums;
 using RaptorSheets.Stock.Helpers;
 using RaptorSheets.Core.Models.Google;
 using SheetName = RaptorSheets.Stock.Enums.SheetName;
@@ -67,6 +68,18 @@ public class SheetManager : SheetManagerBase<SheetEntity>, ISheetManager
     protected override BatchUpdateSpreadsheetRequest GenerateSheetsRequest(List<string> sheetNames)
     {
         return GenerateSheetHelpers.Generate(sheetNames);
+    }
+
+    /// <summary>
+    /// Resolves a self-healed column's raw Validation name into a concrete data validation rule,
+    /// restoring dropdowns on a re-inserted column (GitHub issue #103). Stock's resolver takes no
+    /// range parameter - none of its validations are self-referential.
+    /// </summary>
+    protected override DataValidationRule? GetDataValidation(ColumnInsertionInfo column)
+    {
+        return string.IsNullOrEmpty(column.Validation)
+            ? null
+            : StockSheetHelpers.GetDataValidation(column.Validation.GetValueFromName<Validation>());
     }
 
     // Only the Stocks sheet is genuinely user-writable today (Ticker/Account/Shares - the only


### PR DESCRIPTION
## Summary

Four related fixes in the self-heal/write-path neighborhood, bundled into one PR:

- **#103** - Self-heal now restores dropdown `Validation` on a re-inserted column, not just Formula/Format/Note/Protect (PR #99's gap). New `SheetManagerBase.GetDataValidation(ColumnInsertionInfo)` hook, defaulting to a no-op, overridden per domain to delegate to its existing validation resolver.
- **#101** - Fixes a data-loss bug: `CreateUpdateCellRequests` classified append- vs update-eligible rows using the sheet's grid *capacity* (`MAX_ROW`, ~1000 by default) instead of its actual data extent (`MAX_ROW_VALUE`). On a sparsely-populated sheet, this let an "update" row's explicit target collide with where `AppendCells` lands in the same batch - the update silently clobbered the appended row. Now keyed off `MAX_ROW_VALUE`.
- **#102** - `DeleteSheets` 500'd reliably (5/5 reproduced live) when 2+ protected sheets were deleted in one batch (Stock's Accounts/Tickers). Now splits into separate batch calls once 2+ sheets-to-delete are protected; 0/1 protected sheets keep the original single-batch path unchanged. **Live-verified against Stock's real spreadsheet** - the previously-500ing scenario now passes.
- **#53** (remaining scope) - New opt-in `DetectBrokenColumnsAsync`/`ReapplyColumnFormulas` detect and fix a column that exists on both sides but whose live Formula has drifted from canonical. Scoped to Formula only - a live-read `Validation` is the raw condition off the sheet while canonical is a domain enum token, so they can't be reliably compared (documented on `SheetStructureHelper`).

## Test plan

- [x] `dotnet build` - full solution, 0 warnings/errors
- [x] `dotnet test` (unit) - Core 971, Gig 582, Stock 49, Home 38, Job 32, all passing
- [x] Live integration test (`StockPlumbingTests.DeleteAllSheets_ThenCreateAllSheets_UsesTempSheetSafetyNet`) run against Stock's real spreadsheet to confirm #102's fix - passed (previously 500'd)
- [x] New regression test for #101 reproducing the exact append/update collision scenario
- [x] New unit + end-to-end behavior tests for #103's validation restoration and #53's drift detect/reapply, across Core/Gig/Stock/Home/Job

🤖 Generated with [Claude Code](https://claude.com/claude-code)