### PR TITLE
Implement ReapplyColors, ReapplyFrozenRows, and ReapplyProtection (#28)

### DIFF
--- a/RaptorSheets.Core.Tests/Unit/Managers/SheetManagerGenericBaseTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Managers/SheetManagerGenericBaseTests.cs
@@ -1183,6 +1183,78 @@ public class SheetManagerGenericBaseTests
         mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task ReapplyFormatting_WithOnlyReapplyBordersSet_ReturnsNotImplementedMessageWithoutApiCall()
+    {
+        // Copilot review on PR #107: ReapplyBorders alone must short-circuit with a message
+        // explaining why, instead of silently resolving sheet ids for nothing and returning the
+        // same generic "nothing to reapply" message a caller who set no flags at all would get.
+        var mockService = new Mock<IGoogleSheetService>();
+        var manager = new TestManager(mockService.Object, BuildRegistryWithFormattedHeader(), [SheetName]);
+
+        var result = await manager.ReapplyFormatting(SheetName, new FormattingOptionsEntity { ReapplyColumnFormats = false, ReapplyBorders = true });
+
+        Assert.Contains(result.Messages, m => m.Message.Contains("ReapplyBorders is not implemented yet"));
+        mockService.Verify(s => s.GetSheetInfo(It.IsAny<CancellationToken>()), Times.Never);
+        mockService.Verify(s => s.GetSheetInfo(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()), Times.Never);
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReapplyFormatting_WithReapplyColors_WhenLiveMetadataFetchFails_AbortsWithError()
+    {
+        // Copilot review on PR #107: proceeding without live metadata when ReapplyColors/
+        // ReapplyProtection need it would silently degrade into always-add instead of
+        // update-or-add/delete-then-add, corrupting the sheet with duplicate banded or protected
+        // ranges rather than reapplying cleanly - must abort instead.
+        var mockService = new Mock<IGoogleSheetService>();
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync((Spreadsheet?)null);
+
+        var manager = new TestManager(mockService.Object, BuildRegistryWithFormattedHeader(), [SheetName]);
+
+        var result = await manager.ReapplyFormatting(SheetName, new FormattingOptionsEntity { ReapplyColumnFormats = false, ReapplyColors = true });
+
+        Assert.Contains(result.Messages, m => m.Message.Contains("Unable to retrieve live sheet metadata"));
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReapplyFormatting_WithReapplyProtection_WhenLiveMetadataFetchFails_AbortsWithError()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync((Spreadsheet?)null);
+
+        var manager = new TestManager(mockService.Object, BuildRegistryWithFormattedHeader(), [SheetName]);
+
+        var result = await manager.ReapplyFormatting(SheetName, new FormattingOptionsEntity { ReapplyColumnFormats = false, ReapplyProtection = true });
+
+        Assert.Contains(result.Messages, m => m.Message.Contains("Unable to retrieve live sheet metadata"));
+        mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReapplyFormatting_WithReapplyColors_WhenLiveSheetHasNullProperties_DoesNotThrow()
+    {
+        // Copilot review on PR #107: a live Sheet entry with null Properties (partially-populated
+        // API response) must be skipped, not throw a NullReferenceException and break the whole call.
+        var mockService = new Mock<IGoogleSheetService>();
+        var spreadsheet = SpreadsheetWith((SheetName, 10));
+        spreadsheet.Sheets.Add(new Sheet { Properties = null! });
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        BatchUpdateSpreadsheetRequest? captured = null;
+        mockService.Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new TestManager(mockService.Object, BuildRegistryWithFormattedHeader(), [SheetName]);
+
+        var result = await manager.ReapplyFormatting(SheetName, new FormattingOptionsEntity { ReapplyColumnFormats = false, ReapplyColors = true });
+
+        Assert.NotNull(captured);
+        Assert.Contains(result.Messages, m => m.Message.Contains("Reapplied colors for"));
+    }
+
     // ReapplyColors/ReapplyFrozenRows/ReapplyProtection (#28) - the remaining FormattingOptionsEntity
     // flags beyond ReapplyColumnFormats. ReapplyBorders stays unimplemented (needs a new attribute
     // surface - see FormattingOptionsEntity's doc comment) and isn't covered here.

--- a/RaptorSheets.Core.Tests/Unit/Managers/SheetManagerGenericBaseTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Managers/SheetManagerGenericBaseTests.cs
@@ -1,6 +1,7 @@
 using Google.Apis.Sheets.v4.Data;
 using Microsoft.Extensions.Logging;
 using Moq;
+using RaptorSheets.Core.Constants;
 using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Extensions;
@@ -1181,4 +1182,156 @@ public class SheetManagerGenericBaseTests
         Assert.Contains(result.Messages, m => m.Message.Contains("does not exist"));
         mockService.Verify(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    // ReapplyColors/ReapplyFrozenRows/ReapplyProtection (#28) - the remaining FormattingOptionsEntity
+    // flags beyond ReapplyColumnFormats. ReapplyBorders stays unimplemented (needs a new attribute
+    // surface - see FormattingOptionsEntity's doc comment) and isn't covered here.
+
+    [Fact]
+    public async Task ReapplyFormatting_WithReapplyColors_SetsTabColorAndAddsBandingWhenNoneExistsLive()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        var spreadsheet = SpreadsheetWith((SheetName, 10)); // no BandedRanges - nothing live to update
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        BatchUpdateSpreadsheetRequest? captured = null;
+        mockService.Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new TestManager(mockService.Object, BuildRegistryWithFormattedHeader(), [SheetName]);
+
+        var result = await manager.ReapplyFormatting(SheetName, new FormattingOptionsEntity { ReapplyColumnFormats = false, ReapplyColors = true });
+
+        Assert.NotNull(captured);
+        var propertiesRequest = captured!.Requests.Single(r => r.UpdateSheetProperties != null);
+        Assert.Equal("tabColor", propertiesRequest.UpdateSheetProperties.Fields);
+        Assert.Equal(10, propertiesRequest.UpdateSheetProperties.Properties.SheetId);
+
+        var bandingRequest = captured.Requests.Single(r => r.AddBanding != null || r.UpdateBanding != null);
+        Assert.NotNull(bandingRequest.AddBanding); // no banding existed live - falls back to Add
+        Assert.Equal(10, bandingRequest.AddBanding.BandedRange.BandedRangeId);
+
+        Assert.Contains(result.Messages, m => m.Message.Contains("Reapplied colors for"));
+    }
+
+    [Fact]
+    public async Task ReapplyFormatting_WithReapplyColors_UpdatesExistingBandingInPlace()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        var spreadsheet = SpreadsheetWith((SheetName, 10));
+        spreadsheet.Sheets[0].BandedRanges = [new BandedRange { BandedRangeId = 10 }];
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        BatchUpdateSpreadsheetRequest? captured = null;
+        mockService.Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new TestManager(mockService.Object, BuildRegistryWithFormattedHeader(), [SheetName]);
+
+        await manager.ReapplyFormatting(SheetName, new FormattingOptionsEntity { ReapplyColumnFormats = false, ReapplyColors = true });
+
+        var bandingRequest = captured!.Requests.Single(r => r.AddBanding != null || r.UpdateBanding != null);
+        Assert.NotNull(bandingRequest.UpdateBanding);
+        Assert.Equal(10, bandingRequest.UpdateBanding.BandedRange.BandedRangeId);
+        Assert.Equal("rowProperties", bandingRequest.UpdateBanding.Fields);
+    }
+
+    [Fact]
+    public async Task ReapplyFormatting_WithReapplyFrozenRows_SetsFrozenRowAndColumnMask()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        var spreadsheet = SpreadsheetWith((SheetName, 10));
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        BatchUpdateSpreadsheetRequest? captured = null;
+        mockService.Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new TestManager(mockService.Object, BuildRegistryWithFormattedHeader(), [SheetName]);
+
+        var result = await manager.ReapplyFormatting(SheetName, new FormattingOptionsEntity { ReapplyColumnFormats = false, ReapplyFrozenRows = true });
+
+        var request = Assert.Single(captured!.Requests);
+        Assert.Equal("gridProperties.frozenRowCount,gridProperties.frozenColumnCount", request.UpdateSheetProperties.Fields);
+        Assert.Contains(result.Messages, m => m.Message.Contains("Reapplied frozen rows for"));
+    }
+
+    [Fact]
+    public async Task ReapplyFormatting_WithColorsAndFrozenRowsTogether_BuildsOneCombinedPropertiesRequest()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        var spreadsheet = SpreadsheetWith((SheetName, 10));
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        BatchUpdateSpreadsheetRequest? captured = null;
+        mockService.Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new TestManager(mockService.Object, BuildRegistryWithFormattedHeader(), [SheetName]);
+
+        var result = await manager.ReapplyFormatting(SheetName, new FormattingOptionsEntity { ReapplyColumnFormats = false, ReapplyColors = true, ReapplyFrozenRows = true });
+
+        // One combined UpdateSheetProperties request, not two separate ones.
+        var propertiesRequest = captured!.Requests.Single(r => r.UpdateSheetProperties != null);
+        var fields = (string)propertiesRequest.UpdateSheetProperties.Fields;
+        Assert.Contains("tabColor", fields);
+        Assert.Contains("frozenRowCount", fields);
+
+        Assert.Contains(result.Messages, m => m.Message.Contains("Reapplied colors, frozen rows for"));
+    }
+
+    [Fact]
+    public async Task ReapplyFormatting_WithReapplyProtection_DeletesOwnedRangesLeavesUserRangesAndReadds()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        var spreadsheet = SpreadsheetWith((SheetName, 10));
+        spreadsheet.Sheets[0].ProtectedRanges =
+        [
+            new ProtectedRange { ProtectedRangeId = 1, Description = ProtectionWarnings.HeaderWarning },
+            new ProtectedRange { ProtectedRangeId = 2, Description = "A user's own manual note" }
+        ];
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        BatchUpdateSpreadsheetRequest? captured = null;
+        mockService.Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new TestManager(mockService.Object, BuildRegistryWithFormattedHeader(), [SheetName]);
+
+        var result = await manager.ReapplyFormatting(SheetName, new FormattingOptionsEntity { ReapplyColumnFormats = false, ReapplyProtection = true });
+
+        Assert.NotNull(captured);
+        var deletedIds = captured!.Requests.Where(r => r.DeleteProtectedRange != null).Select(r => r.DeleteProtectedRange.ProtectedRangeId).ToList();
+        Assert.Equal([1], deletedIds); // only the library-owned range, never the user's own
+
+        Assert.Contains(captured.Requests, r => r.AddProtectedRange != null); // fresh protection re-added
+        Assert.Contains(result.Messages, m => m.Message.Contains("Reapplied protection for"));
+    }
+
+    [Fact]
+    public async Task ReapplyFormatting_WithReapplyProtection_NoExistingProtection_OnlyAddsFresh()
+    {
+        var mockService = new Mock<IGoogleSheetService>();
+        var spreadsheet = SpreadsheetWith((SheetName, 10)); // no ProtectedRanges yet
+        mockService.Setup(s => s.GetSheetInfo(It.IsAny<CancellationToken>())).ReturnsAsync(spreadsheet);
+
+        BatchUpdateSpreadsheetRequest? captured = null;
+        mockService.Setup(s => s.BatchUpdateSpreadsheet(It.IsAny<BatchUpdateSpreadsheetRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BatchUpdateSpreadsheetRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync(new BatchUpdateSpreadsheetResponse());
+
+        var manager = new TestManager(mockService.Object, BuildRegistryWithFormattedHeader(), [SheetName]);
+
+        await manager.ReapplyFormatting(SheetName, new FormattingOptionsEntity { ReapplyColumnFormats = false, ReapplyProtection = true });
+
+        Assert.DoesNotContain(captured!.Requests, r => r.DeleteProtectedRange != null);
+        Assert.Contains(captured.Requests, r => r.AddProtectedRange != null);
+    }
+
 }

--- a/RaptorSheets.Core/Entities/FormattingOptionsEntity.cs
+++ b/RaptorSheets.Core/Entities/FormattingOptionsEntity.cs
@@ -3,12 +3,11 @@ namespace RaptorSheets.Core.Entities;
 /// <summary>
 /// Which categories of a sheet's formatting to reapply via
 /// <see cref="Managers.SheetManagerBase{TEntity}.ReapplyFormatting(List{string}, FormattingOptionsEntity?, CancellationToken)"/>
-/// (see GitHub issue #28). Only <see cref="ReapplyColumnFormats"/> is implemented today - the other
-/// four flags exist so the public API shape doesn't need to break when they land. Each needs its own
-/// new Google API request builder (tab/banding colors and frozen rows need an UpdateSheetProperties
-/// builder; protection needs a read-then-delete-then-readd pass to dedupe against this library's own
-/// previously-added ProtectedRanges; borders need a new per-column attribute surface that doesn't
-/// exist yet) - tracked as follow-up work, not attempted here.
+/// (see GitHub issue #28). <see cref="ReapplyBorders"/> is the one flag still unimplemented - it
+/// needs a new per-column attribute surface (a border style configuration point on
+/// <c>ColumnAttribute</c>/<c>SheetCellModel</c>) that doesn't exist yet, a bigger, separate task from
+/// the other four (which only needed new Google API request builders, no schema change). Setting it
+/// is accepted but is currently a no-op.
 /// </summary>
 public class FormattingOptionsEntity
 {

--- a/RaptorSheets.Core/Enums/Field.cs
+++ b/RaptorSheets.Core/Enums/Field.cs
@@ -42,5 +42,24 @@ public enum Field
     /// or note.
     /// </summary>
     [Description("dataValidation")]
-    DATA_VALIDATION
+    DATA_VALIDATION,
+
+    /// <summary>
+    /// Use this field to update only a sheet's tab color.
+    /// </summary>
+    [Description("tabColor")]
+    TAB_COLOR,
+
+    /// <summary>
+    /// Use this field to update only a sheet's frozen row/column counts.
+    /// </summary>
+    [Description("gridProperties.frozenRowCount,gridProperties.frozenColumnCount")]
+    FROZEN_ROWS_AND_COLUMNS,
+
+    /// <summary>
+    /// Use this field to update only a banded range's row/column color properties, without touching
+    /// its range bounds.
+    /// </summary>
+    [Description("rowProperties")]
+    BANDING_ROW_PROPERTIES
 }

--- a/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
+++ b/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
@@ -516,6 +516,101 @@ public static class GoogleRequestHelpers
     }
 
     /// <summary>
+    /// Builds the UpdateSheetProperties request behind <see cref="Managers.SheetManagerBase{TEntity}.ReapplyFormatting(List{string}, Entities.FormattingOptionsEntity?, CancellationToken)"/>'s
+    /// <c>ReapplyColors</c> (tab color) and <c>ReapplyFrozenRows</c> flags - both are plain
+    /// <see cref="SheetProperties"/> fields, so one request/field-mask covers whichever of the two
+    /// the caller asked for (GitHub issue #28). Returns null when neither applies - nothing to send.
+    /// </summary>
+    public static Request? GenerateSheetPropertiesReapplyRequest(SheetModel sheet, int sheetId, bool includeTabColor, bool includeFrozenRows)
+    {
+        if (!includeTabColor && !includeFrozenRows)
+        {
+            return null;
+        }
+
+        var properties = new SheetProperties { SheetId = sheetId };
+        var fields = new List<string>();
+
+        if (includeTabColor)
+        {
+            properties.TabColor = SheetHelpers.GetColor(sheet.TabColor);
+            fields.Add(Field.TAB_COLOR.GetDescription());
+        }
+
+        if (includeFrozenRows)
+        {
+            properties.GridProperties = new GridProperties { FrozenRowCount = sheet.FreezeRowCount, FrozenColumnCount = sheet.FreezeColumnCount };
+            fields.Add(Field.FROZEN_ROWS_AND_COLUMNS.GetDescription());
+        }
+
+        return new Request
+        {
+            UpdateSheetProperties = new UpdateSheetPropertiesRequest
+            {
+                Properties = properties,
+                Fields = string.Join(",", fields)
+            }
+        };
+    }
+
+    /// <summary>
+    /// Builds the other half of <c>ReapplyColors</c> - alternating row banding (GitHub issue #28).
+    /// <see cref="GenerateBandingRequest(SheetModel)"/> (sheet creation) deliberately sets
+    /// <c>BandedRangeId = sheet.Id</c>, so a banded range created by this library always has a known,
+    /// predictable ID - if one still exists live (<paramref name="bandingExists"/>, checked by the
+    /// caller against the sheet's current <c>BandedRanges</c>), update it in place; otherwise fall
+    /// back to adding a fresh one (e.g. a sheet whose banding was manually removed since creation).
+    /// </summary>
+    public static Request GenerateBandingReapplyRequest(SheetModel sheet, int sheetId, bool bandingExists)
+    {
+        var bandedRange = new BandedRange
+        {
+            BandedRangeId = sheetId,
+            Range = new GridRange { SheetId = sheetId },
+            RowProperties = new BandingProperties { HeaderColor = SheetHelpers.GetColor(sheet.TabColor), FirstBandColor = SheetHelpers.GetColor(SheetColor.WHITE), SecondBandColor = SheetHelpers.GetColor(sheet.CellColor) }
+        };
+
+        if (bandingExists)
+        {
+            return new Request
+            {
+                UpdateBanding = new UpdateBandingRequest
+                {
+                    BandedRange = bandedRange,
+                    Fields = Field.BANDING_ROW_PROPERTIES.GetDescription()
+                }
+            };
+        }
+
+        return new Request { AddBanding = new AddBandingRequest { BandedRange = bandedRange } };
+    }
+
+    /// <summary>
+    /// Builds the delete half of <c>ReapplyProtection</c> (GitHub issue #28): a
+    /// <see cref="DeleteProtectedRangeRequest"/> for every existing protected range this library
+    /// itself added, identified by <see cref="Description"/> matching one of
+    /// <see cref="ProtectionWarnings"/>'s three marker strings - a user's own manually-added
+    /// protection never matches these and is left untouched. The caller is expected to follow this
+    /// with fresh add requests (<see cref="GenerateProtectedRangeForHeaderOrSheet"/> plus one
+    /// <see cref="GenerateColumnProtection"/> per formula column) in the same batch - Google applies
+    /// a batch's requests in array order, so delete-then-add for the same conceptual range is safe.
+    /// </summary>
+    public static List<Request> GenerateDeleteOwnedProtectionRequests(IList<ProtectedRange>? existingProtectedRanges)
+    {
+        if (existingProtectedRanges == null)
+        {
+            return [];
+        }
+
+        var ownedDescriptions = new HashSet<string> { ProtectionWarnings.SheetWarning, ProtectionWarnings.HeaderWarning, ProtectionWarnings.ColumnWarning };
+
+        return existingProtectedRanges
+            .Where(r => r.ProtectedRangeId.HasValue && r.Description != null && ownedDescriptions.Contains(r.Description))
+            .Select(r => new Request { DeleteProtectedRange = new DeleteProtectedRangeRequest { ProtectedRangeId = r.ProtectedRangeId!.Value } })
+            .ToList();
+    }
+
+    /// <summary>
     /// Computes the target zero-based sheet index for moving a sheet to the end position
     /// after adding new sheets in the same batch operation.
     /// </summary>

--- a/RaptorSheets.Core/Managers/SheetManagerBase.cs
+++ b/RaptorSheets.Core/Managers/SheetManagerBase.cs
@@ -1384,10 +1384,11 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
     /// <summary>
     /// Re-applies formatting from a sheet's canonical, in-memory SheetModel (the domain's own
     /// XMapper.GetSheet(), via the registry) onto the live sheet - the manual counterpart to the
-    /// automatic self-heal this base already does for missing sheets/columns (see #28). Only
-    /// <see cref="FormattingOptionsEntity.ReapplyColumnFormats"/> is implemented today; see that
-    /// type's doc comment for the rest. Deliberately opt-in only, never triggered from a read -
-    /// matches this library's reads-never-mutate precedent.
+    /// automatic self-heal this base already does for missing sheets/columns (see #28).
+    /// <see cref="FormattingOptionsEntity.ReapplyBorders"/> is still unimplemented (needs a new
+    /// per-column attribute surface that doesn't exist yet - a bigger, separate task); every other
+    /// flag is live. Deliberately opt-in only, never triggered from a read - matches this library's
+    /// reads-never-mutate precedent.
     /// </summary>
     public async Task<TEntity> ReapplyFormatting(string sheet, FormattingOptionsEntity? options = null, CancellationToken cancellationToken = default)
     {
@@ -1400,16 +1401,24 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
         var entity = new TEntity();
         options ??= new FormattingOptionsEntity();
 
-        if (!options.ReapplyColumnFormats)
+        if (!options.ReapplyColumnFormats && !options.ReapplyColors && !options.ReapplyProtection && !options.ReapplyFrozenRows && !options.ReapplyBorders)
         {
-            // Only ReapplyColumnFormats is implemented today (see FormattingOptionsEntity's doc
-            // comment) - the other flags are accepted but are no-ops, so this message must not imply
-            // they did something just because the caller set them.
-            entity.Messages.Add(MessageHelpers.CreateInfoMessage("ReapplyColumnFormats is disabled - nothing to reapply (other FormattingOptionsEntity flags are not implemented yet)", MessageType.GENERAL));
+            entity.Messages.Add(MessageHelpers.CreateInfoMessage("All FormattingOptionsEntity flags are disabled - nothing to reapply", MessageType.GENERAL));
             return entity;
         }
 
-        var sheetIdsByName = await ResolveSheetIdsViaPropertiesAsync(sheets, cancellationToken);
+        // ReapplyColors/ReapplyProtection need live ProtectedRanges/BandedRanges to reapply
+        // correctly (update-in-place vs. add-fresh, and which protection to delete before re-adding)
+        // - only pay for the full metadata fetch when one of them is actually requested. A plain
+        // spreadsheets.get with no ranges/IncludeGridData already returns both, so this is one call
+        // either way, not an extra one on top of the existing sheet-properties lookup.
+        var needsLiveMetadata = options.ReapplyColors || options.ReapplyProtection;
+        var spreadsheetInfo = needsLiveMetadata ? await _googleSheetService.GetSheetInfo(cancellationToken) : null;
+
+        var sheetIdsByName = spreadsheetInfo != null
+            ? ResolveSheetIdsFromSpreadsheet(sheets, spreadsheetInfo)
+            : await ResolveSheetIdsViaPropertiesAsync(sheets, cancellationToken);
+
         var requests = new List<Request>();
 
         foreach (var sheetName in sheets)
@@ -1428,30 +1437,112 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
             }
 
             sheetModel.Headers.UpdateColumns();
-
-            foreach (var header in sheetModel.Headers)
-            {
-                var request = GoogleRequestHelpers.GenerateColumnFormatRequest(sheetId, header.Index, header.Format, header.FormatPattern);
-                if (request != null)
-                {
-                    requests.Add(request);
-                }
-            }
+            AddReapplyRequestsForSheet(options, sheetModel, sheetId, spreadsheetInfo, requests);
         }
 
         if (requests.Count == 0)
         {
-            entity.Messages.Add(MessageHelpers.CreateInfoMessage("No column formats to reapply", MessageType.GENERAL));
+            entity.Messages.Add(MessageHelpers.CreateInfoMessage("Nothing to reapply", MessageType.GENERAL));
             return entity;
         }
 
         var response = await _googleSheetService.BatchUpdateSpreadsheet(new BatchUpdateSpreadsheetRequest { Requests = requests }, cancellationToken);
 
         entity.Messages.Add(response != null
-            ? MessageHelpers.CreateInfoMessage($"Reapplied column formats for {string.Join(", ", sheets)}", MessageType.GENERAL)
+            ? MessageHelpers.CreateInfoMessage($"Reapplied {BuildAppliedCategoriesLabel(options)} for {string.Join(", ", sheets)}", MessageType.GENERAL)
             : MessageHelpers.CreateErrorMessage("Failed to reapply formatting", MessageType.GENERAL));
 
         return entity;
+    }
+
+    /// <summary>
+    /// Builds every request for one sheet across whichever <see cref="FormattingOptionsEntity"/>
+    /// flags are set, appending them onto the shared <paramref name="requests"/> list that
+    /// <see cref="ReapplyFormatting(List{string}, FormattingOptionsEntity?, CancellationToken)"/>
+    /// sends as one batch for every sheet.
+    /// </summary>
+    private static void AddReapplyRequestsForSheet(FormattingOptionsEntity options, Models.Google.SheetModel sheetModel, int sheetId, Spreadsheet? spreadsheetInfo, List<Request> requests)
+    {
+        if (options.ReapplyColumnFormats)
+        {
+            AddColumnFormatReapplyRequests(sheetModel, sheetId, requests);
+        }
+
+        var propertiesRequest = GoogleRequestHelpers.GenerateSheetPropertiesReapplyRequest(sheetModel, sheetId, options.ReapplyColors, options.ReapplyFrozenRows);
+        if (propertiesRequest != null)
+        {
+            requests.Add(propertiesRequest);
+        }
+
+        var liveSheet = spreadsheetInfo?.Sheets?.FirstOrDefault(s => s.Properties.SheetId == sheetId);
+
+        if (options.ReapplyColors)
+        {
+            var bandingExists = liveSheet?.BandedRanges?.Any(b => b.BandedRangeId == sheetId) ?? false;
+            requests.Add(GoogleRequestHelpers.GenerateBandingReapplyRequest(sheetModel, sheetId, bandingExists));
+        }
+
+        if (options.ReapplyProtection)
+        {
+            AddProtectionReapplyRequests(sheetModel, sheetId, liveSheet, requests);
+        }
+    }
+
+    private static string BuildAppliedCategoriesLabel(FormattingOptionsEntity options)
+    {
+        var categories = new List<string>();
+        if (options.ReapplyColumnFormats) categories.Add("column formats");
+        if (options.ReapplyColors) categories.Add("colors");
+        if (options.ReapplyFrozenRows) categories.Add("frozen rows");
+        if (options.ReapplyProtection) categories.Add("protection");
+
+        return string.Join(", ", categories);
+    }
+
+    private static void AddColumnFormatReapplyRequests(Models.Google.SheetModel sheetModel, int sheetId, List<Request> requests)
+    {
+        foreach (var header in sheetModel.Headers)
+        {
+            var request = GoogleRequestHelpers.GenerateColumnFormatRequest(sheetId, header.Index, header.Format, header.FormatPattern);
+            if (request != null)
+            {
+                requests.Add(request);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deletes this library's own previously-added protection (by description marker - see
+    /// <see cref="GoogleRequestHelpers.GenerateDeleteOwnedProtectionRequests"/>) and re-adds it fresh
+    /// against the sheet's *current* canonical layout - the same whole-sheet-or-header range
+    /// <see cref="GoogleRequestHelpers.GenerateProtectedRangeForHeaderOrSheet"/> builds at creation
+    /// time, plus one column-level range per formula column when the sheet itself isn't protected.
+    /// </summary>
+    private static void AddProtectionReapplyRequests(Models.Google.SheetModel sheetModel, int sheetId, Sheet? liveSheet, List<Request> requests)
+    {
+        requests.AddRange(GoogleRequestHelpers.GenerateDeleteOwnedProtectionRequests(liveSheet?.ProtectedRanges));
+
+        // GenerateProtectedRangeForHeaderOrSheet/GenerateColumnProtection read SheetId off the model
+        // itself (same convention sheet creation uses - see SheetGenerationHelper.Generate setting
+        // sheetModel.Id before calling either) rather than taking it as a parameter, so it must be
+        // set to the live id first.
+        sheetModel.Id = sheetId;
+        requests.Add(GoogleRequestHelpers.GenerateProtectedRangeForHeaderOrSheet(sheetModel));
+
+        if (sheetModel.ProtectSheet)
+        {
+            return;
+        }
+
+        requests.AddRange(sheetModel.Headers
+            .Where(header => !string.IsNullOrEmpty(header.Formula))
+            .Select(header => GoogleRequestHelpers.GenerateColumnProtection(new GridRange
+            {
+                SheetId = sheetId,
+                StartColumnIndex = header.Index,
+                EndColumnIndex = header.Index + 1,
+                StartRowIndex = 1,
+            })));
     }
 
     #endregion

--- a/RaptorSheets.Core/Managers/SheetManagerBase.cs
+++ b/RaptorSheets.Core/Managers/SheetManagerBase.cs
@@ -1401,9 +1401,11 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
         var entity = new TEntity();
         options ??= new FormattingOptionsEntity();
 
-        if (!options.ReapplyColumnFormats && !options.ReapplyColors && !options.ReapplyProtection && !options.ReapplyFrozenRows && !options.ReapplyBorders)
+        var hasImplementedFlag = options.ReapplyColumnFormats || options.ReapplyColors || options.ReapplyProtection || options.ReapplyFrozenRows;
+
+        if (!hasImplementedFlag)
         {
-            entity.Messages.Add(MessageHelpers.CreateInfoMessage("All FormattingOptionsEntity flags are disabled - nothing to reapply", MessageType.GENERAL));
+            entity.Messages.Add(MessageHelpers.CreateInfoMessage(BuildNothingToReapplyMessage(options), MessageType.GENERAL));
             return entity;
         }
 
@@ -1413,7 +1415,23 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
         // spreadsheets.get with no ranges/IncludeGridData already returns both, so this is one call
         // either way, not an extra one on top of the existing sheet-properties lookup.
         var needsLiveMetadata = options.ReapplyColors || options.ReapplyProtection;
-        var spreadsheetInfo = needsLiveMetadata ? await _googleSheetService.GetSheetInfo(cancellationToken) : null;
+        Spreadsheet? spreadsheetInfo = null;
+
+        if (needsLiveMetadata)
+        {
+            spreadsheetInfo = await _googleSheetService.GetSheetInfo(cancellationToken);
+
+            if (spreadsheetInfo == null)
+            {
+                // Proceeding without it would silently degrade ReapplyColors/ReapplyProtection into
+                // always-add instead of update-or-add / delete-then-add, corrupting the sheet with
+                // duplicate banded or protected ranges rather than reapplying cleanly - abort instead.
+                entity.Messages.Add(MessageHelpers.CreateErrorMessage(
+                    "Unable to retrieve live sheet metadata required for ReapplyColors/ReapplyProtection",
+                    MessageType.GENERAL));
+                return entity;
+            }
+        }
 
         var sheetIdsByName = spreadsheetInfo != null
             ? ResolveSheetIdsFromSpreadsheet(sheets, spreadsheetInfo)
@@ -1474,7 +1492,7 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
             requests.Add(propertiesRequest);
         }
 
-        var liveSheet = spreadsheetInfo?.Sheets?.FirstOrDefault(s => s.Properties.SheetId == sheetId);
+        var liveSheet = spreadsheetInfo?.Sheets?.FirstOrDefault(s => s.Properties?.SheetId == sheetId);
 
         if (options.ReapplyColors)
         {
@@ -1486,6 +1504,18 @@ public abstract class SheetManagerBase<TEntity> : SheetManagerBase
         {
             AddProtectionReapplyRequests(sheetModel, sheetId, liveSheet, requests);
         }
+    }
+
+    /// <summary>
+    /// Distinguishes "asked for the one flag that isn't implemented yet" from "asked for nothing at
+    /// all" - otherwise a caller who explicitly set only <see cref="FormattingOptionsEntity.ReapplyBorders"/>
+    /// gets the same generic message as one who set nothing, with no hint why.
+    /// </summary>
+    private static string BuildNothingToReapplyMessage(FormattingOptionsEntity options)
+    {
+        return options.ReapplyBorders
+            ? "ReapplyBorders is not implemented yet - nothing to reapply"
+            : "All FormattingOptionsEntity flags are disabled - nothing to reapply";
     }
 
     private static string BuildAppliedCategoriesLabel(FormattingOptionsEntity options)


### PR DESCRIPTION
## Summary

Three of #28's four remaining `FormattingOptionsEntity` flags (`ReapplyColumnFormats` shipped in #99/#104) are now live. Does **not** close #28 - `ReapplyBorders` is deliberately left out, per the issue's own 2026-08-03 scoping comment: it needs a new per-column attribute surface (`BorderStyleEnum` exists but has no configuration point on `ColumnAttribute`/`SheetCellModel` today), a differently-shaped task from the other four, which only needed new Google API request builders.

- **`ReapplyColors`** - tab color via a new `UpdateSheetProperties` builder; alternating row banding via a new builder that updates the live banded range in place when one exists (banded ranges created by this library always use the sheet's own id, so it's a known target) or falls back to adding a fresh one otherwise.
- **`ReapplyFrozenRows`** - shares the same `UpdateSheetProperties` builder as colors, composing one combined field mask when both flags are set instead of sending two separate requests.
- **`ReapplyProtection`** - deletes this library's own previously-added protected ranges (matched by the existing `ProtectionWarnings` description markers, so a user's own manual protection is never touched) and re-adds them fresh against the sheet's current canonical layout, all in one batch (delete-then-add is safe since Google applies a batch's requests in array order).

`ReapplyFormatting` only fetches full live spreadsheet metadata (`ProtectedRanges`/`BandedRanges`) when `ReapplyColors` or `ReapplyProtection` is actually requested - the existing `ReapplyColumnFormats`/`ReapplyFrozenRows`-only path is unchanged and just as cheap as before.

## Test plan

- [x] `dotnet build` - full solution, 0 warnings/errors
- [x] 7 new unit tests: tab-color-only request shape, banding update-in-place vs. add-fresh, frozen-rows field mask, colors+frozen-rows combined into one request, protection delete/re-add while leaving a user's own protected range untouched, and no-existing-protection add-only
- [x] All 3 pre-existing `ReapplyFormatting` tests pass unchanged, including the live integration test (`CorePlumbingTests.ReapplyFormatting_OnPopulatedColumn_PreservesExistingValues`) against the real Core spreadsheet
- [x] Full unit suite: Core 979, Gig 591, Stock 49, Home 38, Job 32 - all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)