### PR TITLE
Read EffectiveValue for numeric FieldTypes on structure-aware reads

### DIFF
--- a/RaptorSheets.Core.Tests/Unit/Helpers/HeaderHelpersTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/HeaderHelpersTests.cs
@@ -140,6 +140,56 @@ public class HeaderHelpersTests
     }
 
     [Fact]
+    public void GetIntValueOrNull_WithNonIntegralSheetCellValue_ShouldReturnNull()
+    {
+        // Arrange - matches the string path's "contains a decimal point -> null" rule; a
+        // fractional EffectiveNumber must not be silently truncated into a wrong integer
+        var headers = new Dictionary<int, string> { { 0, "Count" } };
+        var values = new List<object> { new SheetCellValue("5.9", 5.9) };
+
+        // Act
+        var result = HeaderHelpers.GetIntValueOrNull("Count", values, headers);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(3_000_000_000d)] // beyond int.MaxValue
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void GetIntValueOrNull_WithOutOfRangeSheetCellValue_ShouldReturnNull(double effectiveNumber)
+    {
+        // Arrange
+        var headers = new Dictionary<int, string> { { 0, "Count" } };
+        var values = new List<object> { new SheetCellValue("irrelevant", effectiveNumber) };
+
+        // Act
+        var result = HeaderHelpers.GetIntValueOrNull("Count", values, headers);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(double.MaxValue)] // beyond decimal.MaxValue
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void GetDecimalValueOrNull_WithOutOfRangeSheetCellValue_ShouldReturnNullNotThrow(double effectiveNumber)
+    {
+        // Arrange - decimal's range is far narrower than double's; an unchecked cast would throw
+        // OverflowException here, violating the library's reads-never-fail design
+        var headers = new Dictionary<int, string> { { 0, "Amount" } };
+        var values = new List<object> { new SheetCellValue("irrelevant", effectiveNumber) };
+
+        // Act
+        var result = HeaderHelpers.GetDecimalValueOrNull("Amount", values, headers);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
     public void CheckSheetHeaders_ShouldReturnCorrectMessages()
     {
         // Arrange

--- a/RaptorSheets.Core.Tests/Unit/Helpers/HeaderHelpersTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/HeaderHelpersTests.cs
@@ -95,6 +95,51 @@ public class HeaderHelpersTests
     }
 
     [Fact]
+    public void GetDecimalValueOrNull_WithSheetCellValue_ShouldUseEffectiveNumber()
+    {
+        // Arrange - accounting format renders a real 0 as "$ -", which IsBlankNumericDisplay
+        // would treat as null; a SheetCellValue's EffectiveNumber is the real computed value
+        // and takes priority over re-parsing the display text (issue #80)
+        var headers = new Dictionary<int, string> { { 0, "Amount" } };
+        var values = new List<object> { new SheetCellValue("$ -", 0) };
+
+        // Act
+        var result = HeaderHelpers.GetDecimalValueOrNull("Amount", values, headers);
+
+        // Assert
+        Assert.Equal(0m, result);
+    }
+
+    [Fact]
+    public void GetDecimalValueOrNull_WithSheetCellValueNonZero_ShouldUseEffectiveNumber()
+    {
+        // Arrange - a locale-formatted display ("1,234.50") that a SheetCellValue lets us skip
+        // parsing entirely
+        var headers = new Dictionary<int, string> { { 0, "Amount" } };
+        var values = new List<object> { new SheetCellValue("1,234.50", 1234.50) };
+
+        // Act
+        var result = HeaderHelpers.GetDecimalValueOrNull("Amount", values, headers);
+
+        // Assert
+        Assert.Equal(1234.50m, result);
+    }
+
+    [Fact]
+    public void GetIntValueOrNull_WithSheetCellValue_ShouldUseEffectiveNumber()
+    {
+        // Arrange
+        var headers = new Dictionary<int, string> { { 0, "Count" } };
+        var values = new List<object> { new SheetCellValue("5", 5) };
+
+        // Act
+        var result = HeaderHelpers.GetIntValueOrNull("Count", values, headers);
+
+        // Assert
+        Assert.Equal(5, result);
+    }
+
+    [Fact]
     public void CheckSheetHeaders_ShouldReturnCorrectMessages()
     {
         // Arrange

--- a/RaptorSheets.Core.Tests/Unit/Helpers/SheetHelpersTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/SheetHelpersTests.cs
@@ -462,6 +462,90 @@ public class SheetHelpersTests
         Assert.Equal("ValidRow", result["TestSheet"][0][0]);
     }
 
+    [Fact]
+    public void GetSheetValues_WithNumericEffectiveValue_ShouldWrapAsSheetCellValue()
+    {
+        // Arrange - accounting format renders a real 0 as "$ -"; the EffectiveValue is the
+        // actual computed number regardless of how it's displayed (issue #80)
+        var sheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new()
+                {
+                    Properties = new SheetProperties { Title = "TestSheet" },
+                    Data =
+                    [
+                        new()
+                        {
+                            RowData =
+                            [
+                                new()
+                                {
+                                    Values =
+                                    [
+                                        new() { FormattedValue = "Header" },
+                                        new() { FormattedValue = "$ -", EffectiveValue = new ExtendedValue { NumberValue = 0 } }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // Act
+        var result = SheetHelpers.GetSheetValues(sheet);
+
+        // Assert
+        var cell = Assert.IsType<SheetCellValue>(result["TestSheet"][0][1]);
+        Assert.Equal("$ -", cell.FormattedValue);
+        Assert.Equal(0, cell.EffectiveNumber);
+        Assert.Equal("$ -", cell.ToString()); // non-numeric-aware readers still see the display text
+    }
+
+    [Fact]
+    public void GetSheetValues_WithoutEffectiveValue_ShouldReturnPlainFormattedValue()
+    {
+        // Arrange - a text cell (or any cell without a numeric EffectiveValue) must not be
+        // wrapped, so every existing FormattedValue-only reader keeps working unchanged
+        var sheet = new Spreadsheet
+        {
+            Sheets =
+            [
+                new()
+                {
+                    Properties = new SheetProperties { Title = "TestSheet" },
+                    Data =
+                    [
+                        new()
+                        {
+                            RowData =
+                            [
+                                new()
+                                {
+                                    Values =
+                                    [
+                                        new() { FormattedValue = "Header" },
+                                        new() { FormattedValue = "John", EffectiveValue = new ExtendedValue { StringValue = "John" } }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // Act
+        var result = SheetHelpers.GetSheetValues(sheet);
+
+        // Assert
+        Assert.IsType<string>(result["TestSheet"][0][1]);
+        Assert.Equal("John", result["TestSheet"][0][1]);
+    }
+
     #endregion
 
     #region GetColor Tests

--- a/RaptorSheets.Core.Tests/Unit/Mappers/GenericSheetMapperMappingIssueTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Mappers/GenericSheetMapperMappingIssueTests.cs
@@ -3,6 +3,7 @@ using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Mappers;
+using RaptorSheets.Core.Models.Google;
 using Xunit;
 
 namespace RaptorSheets.Core.Tests.Unit.Mappers;
@@ -112,6 +113,24 @@ public class GenericSheetMapperMappingIssueTests
         var result = GenericSheetMapper<TestEntity>.MapFromRangeData(values, "Sheet1", out var issues);
 
         Assert.Null(result[0].Amount);
+        Assert.Empty(issues);
+    }
+
+    [Fact]
+    public void AccountingDashWithNonZeroEffectiveValue_ShouldReadTheRealNumber()
+    {
+        // A structure-aware read (SheetHelpers.GetSheetValues) carries the real computed number
+        // alongside the display text - proving the actual fix for issue #80, not just the
+        // "treat a dash as null" workaround above: a cell that *displays* as a blank dash but
+        // *is* a real non-zero value (e.g. a format rounding 0.004 down to "$ -") now reads back
+        // correctly instead of being nulled out by the FormattedValue-only heuristic.
+        var values = Rows(
+            ["Name", "Amount", "Count", "Active", "Note"],
+            ["John", new SheetCellValue("$ -", 0.004), "5", "TRUE", ""]);
+
+        var result = GenericSheetMapper<TestEntity>.MapFromRangeData(values, "Sheet1", out var issues);
+
+        Assert.Equal(0.004m, result[0].Amount);
         Assert.Empty(issues);
     }
 

--- a/RaptorSheets.Core/Helpers/HeaderHelpers.cs
+++ b/RaptorSheets.Core/Helpers/HeaderHelpers.cs
@@ -110,6 +110,13 @@ public static class HeaderHelpers
             return null;
         }
 
+        // Structure-aware reads carry the real computed number - use it directly instead of
+        // re-parsing display text, sidestepping locale/formatting quirks entirely (issue #80).
+        if (values[columnId] is SheetCellValue cellValue)
+        {
+            return (int)cellValue.EffectiveNumber;
+        }
+
         var value = values[columnId]?.ToString()?.Trim();
 
         // If the string contains a decimal point, it's not a valid integer
@@ -148,6 +155,16 @@ public static class HeaderHelpers
         if (columnId >= values.Count || columnId < 0 || values[columnId] == null)
         {
             return null;
+        }
+
+        // Structure-aware reads carry the real computed number - use it directly instead of
+        // re-parsing display text. This is the actual fix for issue #80: an accounting-formatted
+        // zero renders as "$ -", which IsBlankNumericDisplay below treats as null rather than 0 -
+        // a real EffectiveValue sidesteps that guess entirely, correct or not, since it's the
+        // literal number Sheets computed.
+        if (values[columnId] is SheetCellValue cellValue)
+        {
+            return (decimal)cellValue.EffectiveNumber;
         }
 
         var value = values[columnId]?.ToString()?.Trim();

--- a/RaptorSheets.Core/Helpers/HeaderHelpers.cs
+++ b/RaptorSheets.Core/Helpers/HeaderHelpers.cs
@@ -112,9 +112,19 @@ public static class HeaderHelpers
 
         // Structure-aware reads carry the real computed number - use it directly instead of
         // re-parsing display text, sidestepping locale/formatting quirks entirely (issue #80).
+        // Matches the string path's semantics below: a non-integral, NaN/Infinity, or
+        // out-of-int-range value isn't a parse failure to hide behind a silent truncation/cast -
+        // it's a genuine type mismatch, so it reads back as null just like "5.9" or "99999999999"
+        // does via the text path.
         if (values[columnId] is SheetCellValue cellValue)
         {
-            return (int)cellValue.EffectiveNumber;
+            var number = cellValue.EffectiveNumber;
+            if (!double.IsInteger(number) || number < int.MinValue || number > int.MaxValue)
+            {
+                return null;
+            }
+
+            return (int)number;
         }
 
         var value = values[columnId]?.ToString()?.Trim();
@@ -161,10 +171,19 @@ public static class HeaderHelpers
         // re-parsing display text. This is the actual fix for issue #80: an accounting-formatted
         // zero renders as "$ -", which IsBlankNumericDisplay below treats as null rather than 0 -
         // a real EffectiveValue sidesteps that guess entirely, correct or not, since it's the
-        // literal number Sheets computed.
+        // literal number Sheets computed. Guard the double->decimal cast first - decimal's range
+        // is far narrower than double's, and an unchecked cast throws OverflowException for
+        // NaN/Infinity/out-of-range values, which would violate reads-never-fail.
         if (values[columnId] is SheetCellValue cellValue)
         {
-            return (decimal)cellValue.EffectiveNumber;
+            var number = cellValue.EffectiveNumber;
+            if (double.IsNaN(number) || double.IsInfinity(number) ||
+                number < (double)decimal.MinValue || number > (double)decimal.MaxValue)
+            {
+                return null;
+            }
+
+            return (decimal)number;
         }
 
         var value = values[columnId]?.ToString()?.Trim();

--- a/RaptorSheets.Core/Helpers/SheetHelpers.cs
+++ b/RaptorSheets.Core/Helpers/SheetHelpers.cs
@@ -66,13 +66,26 @@ public static class SheetHelpers
             }
 
             var values = sheetData.Data[0]?.RowData
-                .Select(x => (IList<object>)x.Values.Select(y => (object)y.FormattedValue).ToList())
+                .Select(x => (IList<object>)x.Values.Select(GetCellValue).ToList())
                 .Where(row => row.Count > 0 && row[0] != null && !string.IsNullOrEmpty(row[0].ToString()))
                 .ToList();
 
             sheetValues.Add(sheetData.Properties.Title, values ?? []);
         }
         return sheetValues;
+    }
+
+    // A structure-aware read (IncludeGridData=true) carries both the display text
+    // (FormattedValue) and the computed value (EffectiveValue) for every cell. Numeric cells get
+    // wrapped in a SheetCellValue so HeaderHelpers' numeric readers can use the real computed
+    // number instead of re-parsing display text (GitHub issue #80, e.g. accounting format
+    // rendering a real 0 as "$ -"). Every other cell keeps its plain FormattedValue string,
+    // unchanged - EffectiveValue's oneof only ever has NumberValue set for numeric cells.
+    private static object? GetCellValue(CellData cell)
+    {
+        return cell.EffectiveValue?.NumberValue is double number
+            ? new SheetCellValue(cell.FormattedValue, number)
+            : cell.FormattedValue;
     }
 
     public static Color GetColor(SheetColor colorEnum)

--- a/RaptorSheets.Core/Models/Google/SheetCellValue.cs
+++ b/RaptorSheets.Core/Models/Google/SheetCellValue.cs
@@ -1,0 +1,25 @@
+namespace RaptorSheets.Core.Models.Google;
+
+/// <summary>
+/// Wraps a Google Sheets cell's display text (FormattedValue) alongside its computed numeric
+/// value (EffectiveValue.NumberValue), for cells read via a structure-aware request
+/// (<see cref="RaptorSheets.Core.Helpers.SheetHelpers.GetSheetValues"/>, IncludeGridData=true)
+/// where both are available. Numeric FieldTypes read <see cref="EffectiveNumber"/> directly
+/// instead of re-parsing display text, sidestepping locale/currency-symbol/accounting-dash text
+/// quirks entirely (GitHub issue #80). Every other FieldType is unaffected: <see cref="ToString"/>
+/// returns <see cref="FormattedValue"/>, so the existing text-based readers (dates, strings,
+/// booleans) keep working unchanged against this type without needing to know it exists.
+/// </summary>
+public class SheetCellValue
+{
+    public string? FormattedValue { get; }
+    public double EffectiveNumber { get; }
+
+    public SheetCellValue(string? formattedValue, double effectiveNumber)
+    {
+        FormattedValue = formattedValue;
+        EffectiveNumber = effectiveNumber;
+    }
+
+    public override string ToString() => FormattedValue ?? "";
+}


### PR DESCRIPTION
## Summary

Closes #80.

`SheetHelpers.GetSheetValues` only ever read `CellData.FormattedValue` (the display text) off each cell, never `CellData.EffectiveValue` (the actual computed number). That forced `HeaderHelpers` to special-case display quirks one at a time (locale currency symbols, thousands separators, an accounting format rendering a real `0` as a bare `"$ -"`) instead of just reading the real number that was already in the API response.

## Scoping note (important, confirmed before implementing)

`EffectiveValue` only exists on **one** of this library's three read pathways:

- **Default path** (`GetSheets(sheetNames)`) → `spreadsheets.values.batchGetByDataFilter` → plain `ValueRange.Values`, **no `CellData`/`EffectiveValue` ever**. This fix has zero effect here.
- **Structure-aware path** (`GetSheets(sheetNames, includeStructure: true)` / `GetAllSheets(true)` / the Sheet Inspector) → `spreadsheets.get` with `IncludeGridData=true` → real `CellData.EffectiveValue`. **This is the only path the fix helps.**
- **Repository path** (`BaseEntityRepository`/`TripRepository`) → `spreadsheets.values.get` → same as default path, no benefit.

The original accounting-dash false-positive that motivated #80 (`ShiftEntity.TotalTips` etc. showing `"$ -"` and false-triggering #58's mapping-issue diagnostics) happens on the **default** path, where `EffectiveValue` can never exist regardless of this change - that's already fully handled by the existing `IsBlankNumericDisplay` text heuristic, which stays in place unchanged as the fallback for every path that doesn't carry `EffectiveValue`. This PR is a real accuracy improvement for structure-aware reads specifically, not a blanket fix.

## Changes

- **`SheetCellValue`** (new): a thin wrapper carrying both `FormattedValue` and `EffectiveValue.NumberValue` for cells where the latter is present. `ToString()` returns `FormattedValue`, so every FieldType that doesn't know about this type (String/Boolean/DateTime/etc.) keeps working against it unchanged.
- **`SheetHelpers.GetSheetValues`**: wraps a cell in `SheetCellValue` only when `EffectiveValue.NumberValue` is set (i.e. only numeric-looking cells - text/date/bool/blank cells are untouched, no extra allocation).
- **`HeaderHelpers.GetDecimalValueOrNull` / `GetIntValueOrNull`**: check for `SheetCellValue` first and return the real number directly, skipping the regex-based currency-symbol stripping and the accounting-dash guess entirely for those cells.
- No changes needed to `GetStringValue`/`GetBoolValue`/`GetDateValue` or `GenericSheetMapper.TryRecordMappingIssue`'s diagnostic text extraction - they all go through `.ToString()`, which already does the right thing.

## Test plan

- [x] New tests: `SheetHelpersTests` (wrapping behavior, both the numeric and non-numeric cases), `HeaderHelpersTests` (`GetDecimalValueOrNull`/`GetIntValueOrNull` preferring the effective number), `GenericSheetMapperMappingIssueTests` (end-to-end: a cell that *displays* as a blank dash but *is* a real non-zero value now reads back correctly instead of being nulled out by the old text-only heuristic - demonstrating the actual improvement over the existing workaround).
- [x] Full `RaptorSheets.Core.Tests` suite: 1151/1152 passed; the one failure (`DeleteDependentSheet_LeavesInputSheetIntact_ThenRecreatesIt`) is pre-existing shared-live-API-quota flakiness, confirmed by rerunning it in isolation (passed).
- [x] Full solution build: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)