### PR TITLE
Migrate Gig/Stock to shared sheet-generation orchestrator + opt-in named ranges

### DIFF
--- a/RaptorSheets.Core.Tests/Unit/Attributes/ColumnAttributeTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Attributes/ColumnAttributeTests.cs
@@ -173,8 +173,32 @@ public class ColumnAttributeTests
         
         // Act
         var pattern = column.GetEffectiveNumberFormatPattern();
-        
+
         // Assert
         Assert.Equal(CellFormatPatterns.Weekday, pattern);
+    }
+
+    [Fact]
+    public void NamedRange_DefaultsToFalse()
+    {
+        var column = new ColumnAttribute("Test");
+
+        Assert.False(column.NamedRange);
+    }
+
+    [Fact]
+    public void NamedRange_SetViaNamedArgumentConstructor_IsTrue()
+    {
+        var column = new ColumnAttribute("Test", isInput: true, namedRange: true);
+
+        Assert.True(column.NamedRange);
+    }
+
+    [Fact]
+    public void NamedRange_SetViaColumnOptions_IsTrue()
+    {
+        var column = new ColumnAttribute("Test", ColumnOptions.Builder().WithNamedRange().Build());
+
+        Assert.True(column.NamedRange);
     }
 }

--- a/RaptorSheets.Core.Tests/Unit/Helpers/GoogleRequestHelpersTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/GoogleRequestHelpersTests.cs
@@ -395,6 +395,55 @@ public class GoogleRequestHelpersTests
     }
 
     [Fact]
+    public void GenerateNamedRangeRequest_ShouldCoverOnlyTheColumnsDataExcludingTheHeaderRow()
+    {
+        // Arrange
+        var sheet = new SheetModel { Id = 5, Name = "Shifts" };
+        var header = new SheetCellModel { Name = "Total Pay", Index = 3 };
+
+        // Act
+        var result = GoogleRequestHelpers.GenerateNamedRangeRequest(sheet, header);
+
+        // Assert
+        Assert.NotNull(result.AddNamedRange);
+        var range = result.AddNamedRange.NamedRange.Range;
+        Assert.Equal(5, range.SheetId);
+        Assert.Equal(3, range.StartColumnIndex);
+        Assert.Equal(4, range.EndColumnIndex);
+        Assert.Equal(1, range.StartRowIndex); // row 0 (the header) is excluded
+    }
+
+    [Theory]
+    [InlineData("Shifts", "Total Pay", "Shifts_Total_Pay")]
+    [InlineData("Deliveries", "Amt/Trip", "Deliveries_Amt_Trip")]
+    [InlineData("Stocks", "P/E Ratio", "Stocks_P_E_Ratio")]
+    public void GenerateNamedRangeRequest_ShouldSanitizeInvalidIdentifierCharacters(string sheetName, string headerName, string expectedName)
+    {
+        // Arrange
+        var sheet = new SheetModel { Id = 1, Name = sheetName };
+        var header = new SheetCellModel { Name = headerName, Index = 0 };
+
+        // Act
+        var result = GoogleRequestHelpers.GenerateNamedRangeRequest(sheet, header);
+
+        // Assert
+        Assert.Equal(expectedName, result.AddNamedRange.NamedRange.Name);
+    }
+
+    [Fact]
+    public void GenerateNamedRangeRequest_WithHeaderStartingWithDigit_ShouldPrefixUnderscore()
+    {
+        // Google rejects named ranges that look like a cell reference (e.g. "2024_Total") -
+        // guard against a header/sheet name pair that would sanitize down to start with a digit
+        var sheet = new SheetModel { Id = 1, Name = "2024" };
+        var header = new SheetCellModel { Name = "Total", Index = 0 };
+
+        var result = GoogleRequestHelpers.GenerateNamedRangeRequest(sheet, header);
+
+        Assert.Equal("_2024_Total", result.AddNamedRange.NamedRange.Name);
+    }
+
+    [Fact]
     public void GenerateSheetPropertes_ShouldReturnValidRequest()
     {
         // Arrange

--- a/RaptorSheets.Core.Tests/Unit/Helpers/SheetGenerationHelperTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/SheetGenerationHelperTests.cs
@@ -134,4 +134,32 @@ public class SheetGenerationHelperTests
 
         Assert.Equal(["A", "B", "C", "D"], sheetModel.Headers.Select(h => h.Column));
     }
+
+    [Fact]
+    public void Generate_ForColumnFlaggedWithNamedRange_AddsNamedRangeRequest()
+    {
+        // Regression guard: a NamedRange-only header (no Format/Validation/FormatPattern) must
+        // not be silently skipped by the "nothing to format" early-exit that governs whether a
+        // RepeatCell request gets built - named ranges are a separate request entirely.
+        var sheetModel = new SheetModel
+        {
+            Name = "Trips",
+            Headers = [new SheetCellModel { Name = "Key", NamedRange = true }]
+        };
+
+        var result = SheetGenerationHelper.Generate(["Trips"], _ => sheetModel, _ => null);
+
+        var namedRange = result.Requests.Single(r => r.AddNamedRange != null).AddNamedRange.NamedRange;
+        Assert.Equal("Trips_Key", namedRange.Name);
+    }
+
+    [Fact]
+    public void Generate_ForColumnWithoutNamedRangeFlag_DoesNotAddNamedRangeRequest()
+    {
+        var sheetModel = BuildSheetModel("Trips");
+
+        var result = SheetGenerationHelper.Generate(["Trips"], _ => sheetModel, _ => null);
+
+        Assert.DoesNotContain(result.Requests, r => r.AddNamedRange != null);
+    }
 }

--- a/RaptorSheets.Core/Attributes/ColumnAttribute.cs
+++ b/RaptorSheets.Core/Attributes/ColumnAttribute.cs
@@ -79,6 +79,16 @@ public class ColumnAttribute : Attribute
     public bool IgnoreMappingErrors { get; private set; }
 
     /// <summary>
+    /// Gets whether Google Sheets should get a named range for this column's data (excluding the
+    /// header row), named "{SheetName}_{HeaderName}" (non-identifier characters replaced with
+    /// underscores). Opt-in, not automatic - a named range per column on every sheet would add
+    /// dozens to hundreds of entries to a spreadsheet's named range list by default. Set this on
+    /// columns whose range is worth referencing by name (e.g. from another sheet's formula)
+    /// instead of raw A1 notation.
+    /// </summary>
+    public bool NamedRange { get; private set; }
+
+    /// <summary>
     /// Initializes a column configuration for an OUTPUT column (formula/calculated).
     /// FieldType is automatically inferred from the property type.
     /// This is the most common case - use this constructor for columns with formulas.
@@ -188,6 +198,7 @@ public class ColumnAttribute : Attribute
         ValidationPattern = options.ValidationPattern;
         Note = options.Note;
         IgnoreMappingErrors = options.IgnoreMappingErrors;
+        NamedRange = options.NamedRange;
     }
 
     /// <summary>
@@ -204,13 +215,14 @@ public class ColumnAttribute : Attribute
     /// <param name="order">Column order priority (-1 = use declaration order)</param>
     /// <param name="formatType">Format type for Google Sheets display (DEFAULT = use default from fieldType)</param>
     /// <param name="ignoreMappingErrors">Suppress mapping-error diagnostics for this column (see <see cref="IgnoreMappingErrors"/>)</param>
-    // 9 params is intentional: this is the convenience overload for named-argument call sites
+    /// <param name="namedRange">Give this column's data a named range (see <see cref="NamedRange"/>)</param>
+    // 10 params is intentional: this is the convenience overload for named-argument call sites
     // (used pervasively across every domain's entities); the ColumnOptions-based overload above
     // is the designed escape hatch when more configuration is needed. Note that the ColumnOptions
     // overload can only ever be called programmatically, not as a declarative [Column(...)]
     // attribute - attribute arguments must be compile-time constants, and ColumnOptions is a mutable
     // object initializer. This constructor is therefore the only one that can expose a new option
-    // (like ignoreMappingErrors) to code actually using [Column(...)] syntax.
+    // (like ignoreMappingErrors/namedRange) to code actually using [Column(...)] syntax.
 #pragma warning disable S107
     public ColumnAttribute(
         string headerName,
@@ -221,7 +233,8 @@ public class ColumnAttribute : Attribute
         string? validationPattern = null,
         int order = -1,
         Format formatType = Format.DEFAULT,
-        bool ignoreMappingErrors = false)
+        bool ignoreMappingErrors = false,
+        bool namedRange = false)
     {
         HeaderName = headerName ?? throw new ArgumentNullException(nameof(headerName));
         FieldType = FieldType.String; // Default, will be set by SetFieldTypeFromProperty
@@ -234,6 +247,7 @@ public class ColumnAttribute : Attribute
         ValidationPattern = validationPattern;
         Note = note;
         IgnoreMappingErrors = ignoreMappingErrors;
+        NamedRange = namedRange;
     }
 #pragma warning restore S107
 

--- a/RaptorSheets.Core/Attributes/ColumnOptions.cs
+++ b/RaptorSheets.Core/Attributes/ColumnOptions.cs
@@ -58,6 +58,12 @@ public class ColumnOptions
     public bool IgnoreMappingErrors { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets whether Google Sheets should get a named range for this column's data
+    /// (default: false). See <see cref="ColumnAttribute.NamedRange"/>.
+    /// </summary>
+    public bool NamedRange { get; set; } = false;
+
+    /// <summary>
     /// Creates a new ColumnOptions instance with default values.
     /// </summary>
     public ColumnOptions()
@@ -178,6 +184,15 @@ public class ColumnOptionsBuilder
     public ColumnOptionsBuilder IgnoreMappingErrors()
     {
         _options.IgnoreMappingErrors = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Gives this column's data a named range - see <see cref="ColumnAttribute.NamedRange"/>.
+    /// </summary>
+    public ColumnOptionsBuilder WithNamedRange()
+    {
+        _options.NamedRange = true;
         return this;
     }
 

--- a/RaptorSheets.Core/Helpers/EntitySheetConfigHelper.cs
+++ b/RaptorSheets.Core/Helpers/EntitySheetConfigHelper.cs
@@ -94,7 +94,8 @@ public static class EntitySheetConfigHelper
         var header = new SheetCellModel
         {
             Name = headerName,
-            Format = columnAttr.GetEffectiveFormat()
+            Format = columnAttr.GetEffectiveFormat(),
+            NamedRange = columnAttr.NamedRange
         };
 
         // Populate FormatPattern - this becomes the single source of truth

--- a/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
+++ b/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
@@ -4,11 +4,15 @@ using RaptorSheets.Core.Entities;
 using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Models.Google;
+using System.Text.RegularExpressions;
 
 namespace RaptorSheets.Core.Helpers;
 
 public static class GoogleRequestHelpers
 {
+    // Google Sheets named ranges must be letters/digits/underscores only and can't start with a
+    // digit (it would look like an A1/R1C1 cell reference and be rejected).
+    private static readonly Regex NonIdentifierCharRegex = new(@"[^A-Za-z0-9_]", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
 
     public static Request GenerateAppendCells(SheetModel sheet)
     {
@@ -422,6 +426,44 @@ public static class GoogleRequestHelpers
         };
 
         return new Request { RepeatCell = repeatCellRequest };
+    }
+
+    /// <summary>
+    /// Builds an AddNamedRangeRequest for a single header column flagged with
+    /// <see cref="RaptorSheets.Core.Attributes.ColumnAttribute.NamedRange"/> (GitHub issue #81) -
+    /// covers that column's data only (row 1, the header, is excluded), named
+    /// "{SheetName}_{HeaderName}" via <see cref="BuildNamedRangeName"/>.
+    /// </summary>
+    public static Request GenerateNamedRangeRequest(SheetModel sheet, SheetCellModel header)
+    {
+        var range = new GridRange
+        {
+            SheetId = sheet.Id,
+            StartColumnIndex = header.Index,
+            EndColumnIndex = header.Index + 1,
+            StartRowIndex = 1,
+        };
+
+        return new Request
+        {
+            AddNamedRange = new AddNamedRangeRequest
+            {
+                NamedRange = new NamedRange
+                {
+                    Name = BuildNamedRangeName(sheet.Name, header.Name),
+                    Range = range
+                }
+            }
+        };
+    }
+
+    // Replaces every character invalid in a Google Sheets named range (spaces, slashes, etc. -
+    // header names like "Amt/Trip" or "Total Pay" are common in this codebase) with an underscore,
+    // and guards against the result starting with a digit.
+    private static string BuildNamedRangeName(string sheetName, string headerName)
+    {
+        var sanitized = NonIdentifierCharRegex.Replace($"{sheetName}_{headerName}", "_");
+        return char.IsDigit(sanitized[0]) ? "_" + sanitized : sanitized;
     }
 
     public static Request GenerateSheetPropertes(SheetModel sheet)

--- a/RaptorSheets.Core/Helpers/SheetGenerationHelper.cs
+++ b/RaptorSheets.Core/Helpers/SheetGenerationHelper.cs
@@ -89,34 +89,48 @@ public static class SheetGenerationHelper
                 batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateColumnProtection(range));
             }
 
-            // If there's no format or validation then go to the next header
-            if (header.Format == null && string.IsNullOrEmpty(header.Validation) && string.IsNullOrEmpty(header.FormatPattern))
+            if (header.NamedRange)
             {
-                continue;
+                batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateNamedRangeRequest(sheet, header));
             }
 
-            var repeatCellModel = new RepeatCellModel
-            {
-                GridRange = range,
-            };
-
-            if (header.Format != null || !string.IsNullOrEmpty(header.FormatPattern))
-            {
-                var formatToUse = header.Format ?? Format.NUMBER; // Default to NUMBER if only pattern provided
-
-                // FormatPattern is the single source of truth - always populated either from a
-                // custom pattern or derived from Format
-                repeatCellModel.CellFormat = !string.IsNullOrEmpty(header.FormatPattern)
-                    ? SheetHelpers.GetCellFormat(formatToUse, header.FormatPattern)
-                    : SheetHelpers.GetCellFormat(formatToUse);
-            }
-
-            if (!string.IsNullOrEmpty(header.Validation))
-            {
-                repeatCellModel.DataValidation = getDataValidation(header);
-            }
-
-            repeatCellRequests.Add(GoogleRequestHelpers.GenerateRepeatCellRequest(repeatCellModel));
+            AddFormatAndValidationRequest(header, range, repeatCellRequests, getDataValidation);
         }
+    }
+
+    private static void AddFormatAndValidationRequest(
+        SheetCellModel header,
+        GridRange range,
+        List<RepeatCellRequest> repeatCellRequests,
+        Func<SheetCellModel, DataValidationRule?> getDataValidation)
+    {
+        // If there's no format or validation then there's nothing to add
+        if (header.Format == null && string.IsNullOrEmpty(header.Validation) && string.IsNullOrEmpty(header.FormatPattern))
+        {
+            return;
+        }
+
+        var repeatCellModel = new RepeatCellModel
+        {
+            GridRange = range,
+        };
+
+        if (header.Format != null || !string.IsNullOrEmpty(header.FormatPattern))
+        {
+            var formatToUse = header.Format ?? Format.NUMBER; // Default to NUMBER if only pattern provided
+
+            // FormatPattern is the single source of truth - always populated either from a
+            // custom pattern or derived from Format
+            repeatCellModel.CellFormat = !string.IsNullOrEmpty(header.FormatPattern)
+                ? SheetHelpers.GetCellFormat(formatToUse, header.FormatPattern)
+                : SheetHelpers.GetCellFormat(formatToUse);
+        }
+
+        if (!string.IsNullOrEmpty(header.Validation))
+        {
+            repeatCellModel.DataValidation = getDataValidation(header);
+        }
+
+        repeatCellRequests.Add(GoogleRequestHelpers.GenerateRepeatCellRequest(repeatCellModel));
     }
 }

--- a/RaptorSheets.Core/Models/Google/SheetCellModel.cs
+++ b/RaptorSheets.Core/Models/Google/SheetCellModel.cs
@@ -26,4 +26,8 @@ public class SheetCellModel
     public bool Protect { get; set; } = false;
     public string Validation { get; set; } = "";
     public string Note { get; set; } = "";
+
+    // Opt-in: gives this column's data (excluding the header row) a Google Sheets named range,
+    // named "{SheetName}_{HeaderName}". See ColumnAttribute.NamedRange.
+    public bool NamedRange { get; set; } = false;
 }

--- a/RaptorSheets.Gig/Helpers/GenerateSheetsHelpers.cs
+++ b/RaptorSheets.Gig/Helpers/GenerateSheetsHelpers.cs
@@ -14,43 +14,7 @@ public static class GenerateSheetsHelpers
 {
     internal static BatchUpdateSpreadsheetRequest Generate(List<string> sheets)
     {
-        if (sheets.Count == 0)
-        {
-            // Skip unnecessary processing when the collection is empty
-            return new BatchUpdateSpreadsheetRequest { Requests = new List<Request>() };
-        }
-
-        var batchUpdateSpreadsheetRequest = new BatchUpdateSpreadsheetRequest
-        {
-            Requests = []
-        };
-        var repeatCellRequests = new List<RepeatCellRequest>();
-
-        foreach (var sheet in sheets)
-        {
-            var sheetModel = GetSheetModel(sheet);
-            sheetModel.Id = Random.Shared.Next();
-
-            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateSheetPropertes(sheetModel));
-
-            var appendDimension = GoogleRequestHelpers.GenerateAppendDimension(sheetModel);
-            if (appendDimension != null)
-            {
-                batchUpdateSpreadsheetRequest.Requests.Add(appendDimension);
-            }
-
-            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateAppendCells(sheetModel));
-            GenerateHeadersFormatAndProtection(sheetModel, batchUpdateSpreadsheetRequest, repeatCellRequests);
-            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateBandingRequest(sheetModel));
-            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateProtectedRangeForHeaderOrSheet(sheetModel));
-        }
-
-        foreach (var request in repeatCellRequests)
-        {
-            batchUpdateSpreadsheetRequest.Requests.Add(new Request { RepeatCell = request });
-        }
-
-        return batchUpdateSpreadsheetRequest;
+        return SheetGenerationHelper.Generate(sheets, GetSheetModel, GetDataValidation);
     }
 
     public static List<string> GetSheetNames()
@@ -96,61 +60,9 @@ public static class GenerateSheetsHelpers
         throw new NotImplementedException($"Sheet model not found for: {sheet}");
     }
 
-    private static void GenerateHeadersFormatAndProtection(
-        SheetModel sheet,
-        BatchUpdateSpreadsheetRequest batchUpdateSpreadsheetRequest,
-        List<RepeatCellRequest> repeatCellRequests)
+    private static DataValidationRule? GetDataValidation(SheetCellModel header)
     {
-        // Ensure headers have proper Column/Index assignments prior to formatting, like Stock implementation
-        sheet.Headers.UpdateColumns();
-
-        // Format/Protect Column Cells
-        foreach (var header in sheet.Headers)
-        {
-            var range = new GridRange
-            {
-                SheetId = sheet.Id,
-                StartColumnIndex = header.Index,
-                EndColumnIndex = header.Index + 1,
-                StartRowIndex = 1,
-            };
-
-            // If whole sheet isn't protected then protect certain columns
-            if (!string.IsNullOrEmpty(header.Formula) && !sheet.ProtectSheet)
-            {
-                batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateColumnProtection(range));
-            }
-
-            // If there's no format or validation then go to next header
-            if (header.Format == null && string.IsNullOrEmpty(header.Validation) && string.IsNullOrEmpty(header.FormatPattern))
-            {
-                continue;
-            }
-
-            var repeatCellModel = new RepeatCellModel
-            {
-                GridRange = range,
-            };
-
-            // Apply formatting if Format or FormatPattern exists
-            if (header.Format != null || !string.IsNullOrEmpty(header.FormatPattern))
-            {
-                var formatToUse = header.Format ?? Format.NUMBER; // Default to NUMBER if only pattern provided
-
-                // FormatPattern is the single source of truth - it's always populated
-                // Either from custom pattern or derived from Format
-                repeatCellModel.CellFormat = !string.IsNullOrEmpty(header.FormatPattern)
-                    ? SheetHelpers.GetCellFormat(formatToUse, header.FormatPattern)
-                    : SheetHelpers.GetCellFormat(formatToUse);
-            }
-
-            if (!string.IsNullOrEmpty(header.Validation))
-            {
-                var columnRange = $"{header.Column}2:{header.Column}";
-                repeatCellModel.DataValidation = GigSheetHelpers.GetDataValidation(header.Validation.GetValueFromName<Validation>(), columnRange);
-            }
-
-            repeatCellRequests.Add(GoogleRequestHelpers.GenerateRepeatCellRequest(repeatCellModel));
-        }
-    }  
+        var columnRange = $"{header.Column}2:{header.Column}";
+        return GigSheetHelpers.GetDataValidation(header.Validation.GetValueFromName<Validation>(), columnRange);
+    }
 }

--- a/RaptorSheets.Stock/Helpers/GenerateSheetHelpers.cs
+++ b/RaptorSheets.Stock/Helpers/GenerateSheetHelpers.cs
@@ -11,44 +11,9 @@ namespace RaptorSheets.Stock.Helpers;
 
 public static class GenerateSheetHelpers
 {
-    private static readonly Random _random = new();
-
     internal static BatchUpdateSpreadsheetRequest Generate(List<string> sheets)
     {
-        var batchUpdateSpreadsheetRequest = new BatchUpdateSpreadsheetRequest { Requests = [] };
-
-        if (sheets.Count == 0)
-        {
-            return batchUpdateSpreadsheetRequest;
-        }
-
-        var repeatCellRequests = new List<RepeatCellRequest>();
-
-        foreach (var sheet in sheets)
-        {
-            var sheetModel = GetSheetModel(sheet);
-            sheetModel.Id = _random.Next();
-
-            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateSheetPropertes(sheetModel));
-
-            var appendDimension = GoogleRequestHelpers.GenerateAppendDimension(sheetModel);
-            if (appendDimension != null)
-            {
-                batchUpdateSpreadsheetRequest.Requests.Add(appendDimension);
-            }
-
-            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateAppendCells(sheetModel));
-            GenerateHeadersFormatAndProtection(sheetModel, batchUpdateSpreadsheetRequest, repeatCellRequests);
-            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateBandingRequest(sheetModel));
-            batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateProtectedRangeForHeaderOrSheet(sheetModel));
-        }
-
-        foreach (var request in repeatCellRequests)
-        {
-            batchUpdateSpreadsheetRequest.Requests.Add(new Request { RepeatCell = request });
-        }
-
-        return batchUpdateSpreadsheetRequest;
+        return SheetGenerationHelper.Generate(sheets, GetSheetModel, GetDataValidation);
     }
 
     // Case-insensitive name -> factory lookup, same convention as SheetRegistry<TEntity>'s own
@@ -75,42 +40,8 @@ public static class GenerateSheetHelpers
         throw new NotImplementedException($"Sheet model not found for: {sheet}");
     }
 
-    private static void GenerateHeadersFormatAndProtection(
-        SheetModel sheet,
-        BatchUpdateSpreadsheetRequest batchUpdateSpreadsheetRequest,
-        List<RepeatCellRequest> repeatCellRequests)
+    private static DataValidationRule? GetDataValidation(SheetCellModel header)
     {
-        // Format/Protect Column Cells
-        sheet.Headers.ForEach(header =>
-        {
-            var range = new GridRange
-            {
-                SheetId = sheet.Id,
-                StartColumnIndex = header.Index,
-                EndColumnIndex = header.Index + 1,
-                StartRowIndex = 1,
-            };
-
-            // If whole sheet isn't protected then protect certain columns
-            if (!string.IsNullOrEmpty(header.Formula) && !sheet.ProtectSheet)
-            {
-                batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateColumnProtection(range));
-            }
-
-            // If there's no format or validation then go to next header
-            if (header.Format == null && string.IsNullOrEmpty(header.Validation))
-            {
-                return;
-            }
-
-            var repeatCellModel = new RepeatCellModel
-            {
-                GridRange = range,
-                CellFormat = (header.Format != null ? SheetHelpers.GetCellFormat((Format)header.Format) : null),
-                DataValidation = (!string.IsNullOrEmpty(header.Validation) ? StockSheetHelpers.GetDataValidation(header.Validation.GetValueFromName<Validation>()) : null)
-            };
-
-            repeatCellRequests.Add(GoogleRequestHelpers.GenerateRepeatCellRequest(repeatCellModel));
-        });
+        return StockSheetHelpers.GetDataValidation(header.Validation.GetValueFromName<Validation>());
     }
 }


### PR DESCRIPTION
## Summary

Part of #81's Tier 1 recommendation ([investigation comment](https://github.com/khanjal/RaptorSheets/issues/81#issuecomment-5235035913)).

**Commit 1 — prerequisite cleanup found during the investigation:** `SheetGenerationHelper.Generate` (Core) is meant to be the shared sheet-creation orchestrator, but only Home and Job actually delegated to it — Gig and Stock each carried their own ~140-line duplicate of the same logic. Migrated both. No intended behavior change: the two divergences found (Stock was missing `UpdateColumns()` and `FormatPattern` handling) are both confirmed no-ops today (`UpdateColumns()` already runs earlier inside `GenericSheetMapper<T>.GetSheet`, and no Stock entity sets a custom `FormatPattern`). Full Gig (639) and Stock (77) suites pass unchanged.

**Commit 2 — named ranges (#81 Tier 1, first of three recommended features):** new `ColumnAttribute.NamedRange` (bool, opt-in) gives a column's data range (excluding the header row) a Google Sheets named range: `{SheetName}_{HeaderName}`, with invalid identifier characters (spaces, slashes — `"Amt/Trip"`, `"Total Pay"` are real header names here) replaced with underscores, and a leading underscore guard against a name that would otherwise start with a digit.

Deliberately **opt-in per column, not automatic** — confirmed with the maintainer before implementing. An unconditional named range per column across every domain sheet would silently add 200+ entries to a spreadsheet's named range list for every existing user on upgrade, which is real clutter nobody asked for.

## Scope note

This PR ships the capability only (opt-in flag → generation-time request). Not included, tracked as explicit follow-ups:
- **Reapply support** — a `FormattingOptionsEntity` flag + a `Generate*ReapplyRequest`, mirroring #28's pattern. Should be simpler than banding/protection's reapply since ownership is inferable from the deterministic name itself (no separate marker needed).
- **Actually using it** — flagging real domain columns with `NamedRange: true` so `GigFormulaBuilder`'s formulas can reference names instead of raw A1 ranges, which is the stated readability payoff from the #81 investigation.

## Test plan

- [x] New tests: `ColumnAttributeTests` (default/both constructors), `GoogleRequestHelpersTests` (range bounds excluding header row, name sanitization across 3 real header-name cases, leading-digit guard), `SheetGenerationHelperTests` (a `NamedRange`-only column with no Format/Validation isn't silently skipped by the "nothing to format" early-exit; a column without the flag gets no named-range request).
- [x] Full `Core.Tests` suite: 1169/1169 passed.
- [x] Full solution build: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)