### PR TITLE
Add opt-in conditional formatting for columns (#81 Tier 1)

### DIFF
--- a/RaptorSheets.Core.Tests/Unit/Attributes/ColumnAttributeTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Attributes/ColumnAttributeTests.cs
@@ -201,4 +201,28 @@ public class ColumnAttributeTests
 
         Assert.True(column.NamedRange);
     }
+
+    [Fact]
+    public void ConditionalFormat_DefaultsToNull()
+    {
+        var column = new ColumnAttribute("Test");
+
+        Assert.Null(column.ConditionalFormat);
+    }
+
+    [Fact]
+    public void ConditionalFormat_SetViaNamedArgumentConstructor_IsSet()
+    {
+        var column = new ColumnAttribute("Test", isInput: true, conditionalFormat: "NEGATIVE_BALANCE");
+
+        Assert.Equal("NEGATIVE_BALANCE", column.ConditionalFormat);
+    }
+
+    [Fact]
+    public void ConditionalFormat_SetViaColumnOptions_IsSet()
+    {
+        var column = new ColumnAttribute("Test", ColumnOptions.Builder().WithConditionalFormat("NEGATIVE_BALANCE").Build());
+
+        Assert.Equal("NEGATIVE_BALANCE", column.ConditionalFormat);
+    }
 }

--- a/RaptorSheets.Core.Tests/Unit/Attributes/ColumnAttributeTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Attributes/ColumnAttributeTests.cs
@@ -225,4 +225,23 @@ public class ColumnAttributeTests
 
         Assert.Equal("NEGATIVE_BALANCE", column.ConditionalFormat);
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ConditionalFormat_SetToBlankViaNamedArgumentConstructor_Throws(string blank)
+    {
+        // A blank value would silently resolve to no conditional format (no separate "enabled"
+        // flag backs it, unlike EnableValidation/ValidationPattern) - reject it as a likely mistake
+        // rather than let it silently do nothing.
+        Assert.Throws<ArgumentException>(() => new ColumnAttribute("Test", isInput: true, conditionalFormat: blank));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ConditionalFormat_SetToBlankViaColumnOptions_Throws(string blank)
+    {
+        Assert.Throws<ArgumentException>(() => ColumnOptions.Builder().WithConditionalFormat(blank).Build());
+    }
 }

--- a/RaptorSheets.Core.Tests/Unit/Helpers/GoogleRequestHelpersTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/GoogleRequestHelpersTests.cs
@@ -444,6 +444,41 @@ public class GoogleRequestHelpersTests
     }
 
     [Fact]
+    public void GenerateConditionalFormatRequest_WithRule_ShouldCoverOnlyTheColumnsDataExcludingTheHeaderRow()
+    {
+        // Arrange
+        var rule = new BooleanRule
+        {
+            Condition = new BooleanCondition { Type = "NUMBER_LESS", Values = [new ConditionValue { UserEnteredValue = "0" }] },
+            Format = new CellFormat { BackgroundColor = new Color { Red = 1 } }
+        };
+
+        // Act
+        var result = GoogleRequestHelpers.GenerateConditionalFormatRequest(sheetId: 5, columnIndex: 3, rule: rule, ruleIndex: 2);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result!.AddConditionalFormatRule);
+        Assert.Equal(2, result.AddConditionalFormatRule.Index);
+        Assert.Same(rule, result.AddConditionalFormatRule.Rule.BooleanRule);
+        var range = Assert.Single(result.AddConditionalFormatRule.Rule.Ranges);
+        Assert.Equal(5, range.SheetId);
+        Assert.Equal(3, range.StartColumnIndex);
+        Assert.Equal(4, range.EndColumnIndex);
+        Assert.Equal(1, range.StartRowIndex); // row 0 (the header) is excluded
+    }
+
+    [Fact]
+    public void GenerateConditionalFormatRequest_WithNullRule_ShouldReturnNull()
+    {
+        // Act
+        var result = GoogleRequestHelpers.GenerateConditionalFormatRequest(sheetId: 1, columnIndex: 0, rule: null, ruleIndex: 0);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
     public void GenerateSheetPropertes_ShouldReturnValidRequest()
     {
         // Arrange

--- a/RaptorSheets.Core.Tests/Unit/Helpers/SheetGenerationHelperTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/SheetGenerationHelperTests.cs
@@ -162,4 +162,86 @@ public class SheetGenerationHelperTests
 
         Assert.DoesNotContain(result.Requests, r => r.AddNamedRange != null);
     }
+
+    [Fact]
+    public void Generate_ForColumnFlaggedWithConditionalFormat_InvokesResolverAndAddsRequest()
+    {
+        var sheetModel = new SheetModel
+        {
+            Name = "Trips",
+            Headers = [new SheetCellModel { Name = "Total", ConditionalFormat = "NEGATIVE_BALANCE" }]
+        };
+        var rule = new BooleanRule { Condition = new BooleanCondition { Type = "NUMBER_LESS" } };
+
+        var result = SheetGenerationHelper.Generate(["Trips"], _ => sheetModel, _ => null, _ => rule);
+
+        var addedRule = result.Requests.Single(r => r.AddConditionalFormatRule != null).AddConditionalFormatRule;
+        Assert.Same(rule, addedRule.Rule.BooleanRule);
+        Assert.Equal(0, addedRule.Index);
+    }
+
+    [Fact]
+    public void Generate_ForMultipleColumnsFlaggedWithConditionalFormat_AssignsSequentialIndexes()
+    {
+        var sheetModel = new SheetModel
+        {
+            Name = "Trips",
+            Headers =
+            [
+                new SheetCellModel { Name = "Pay", ConditionalFormat = "NEGATIVE_BALANCE" },
+                new SheetCellModel { Name = "Tips", ConditionalFormat = "NEGATIVE_BALANCE" }
+            ]
+        };
+
+        var result = SheetGenerationHelper.Generate(
+            ["Trips"], _ => sheetModel, _ => null, _ => new BooleanRule());
+
+        var indexes = result.Requests
+            .Where(r => r.AddConditionalFormatRule != null)
+            .Select(r => r.AddConditionalFormatRule.Index)
+            .ToList();
+        Assert.Equal([0, 1], indexes);
+    }
+
+    [Fact]
+    public void Generate_ForColumnFlaggedWithConditionalFormat_WithoutResolver_AddsNothing()
+    {
+        // Backward-compat guard: getConditionalFormat is optional, so existing callers that don't
+        // pass one (all 4 domains, as of this feature) must be unaffected even if a header happens
+        // to have ConditionalFormat set.
+        var sheetModel = new SheetModel
+        {
+            Name = "Trips",
+            Headers = [new SheetCellModel { Name = "Total", ConditionalFormat = "NEGATIVE_BALANCE" }]
+        };
+
+        var result = SheetGenerationHelper.Generate(["Trips"], _ => sheetModel, _ => null);
+
+        Assert.DoesNotContain(result.Requests, r => r.AddConditionalFormatRule != null);
+    }
+
+    [Fact]
+    public void Generate_ForColumnFlaggedWithConditionalFormat_WhenResolverReturnsNull_AddsNothing()
+    {
+        var sheetModel = new SheetModel
+        {
+            Name = "Trips",
+            Headers = [new SheetCellModel { Name = "Total", ConditionalFormat = "NEGATIVE_BALANCE" }]
+        };
+
+        var result = SheetGenerationHelper.Generate(["Trips"], _ => sheetModel, _ => null, _ => null);
+
+        Assert.DoesNotContain(result.Requests, r => r.AddConditionalFormatRule != null);
+    }
+
+    [Fact]
+    public void Generate_ForColumnWithoutConditionalFormat_DoesNotInvokeResolver()
+    {
+        var sheetModel = BuildSheetModel("Trips");
+        var invoked = false;
+
+        SheetGenerationHelper.Generate(["Trips"], _ => sheetModel, _ => null, _ => { invoked = true; return null; });
+
+        Assert.False(invoked);
+    }
 }

--- a/RaptorSheets.Core/Attributes/ColumnAttribute.cs
+++ b/RaptorSheets.Core/Attributes/ColumnAttribute.cs
@@ -89,6 +89,17 @@ public class ColumnAttribute : Attribute
     public bool NamedRange { get; private set; }
 
     /// <summary>
+    /// Gets a domain-specific conditional-format rule identifier for this column (e.g.
+    /// "NEGATIVE_BALANCE"), or null for none. Mirrors <see cref="ValidationPattern"/>'s pattern:
+    /// the identifier is meaningless to Core - a domain's own resolver (see
+    /// <c>SheetGenerationHelper.Generate</c>'s <c>getConditionalFormat</c> delegate) turns it into
+    /// a concrete <c>BooleanRule</c> (which condition, which highlight color, etc.) at
+    /// generation time, the same way <see cref="ValidationPattern"/> is resolved into a
+    /// <c>DataValidationRule</c> by a domain's <c>GetDataValidation</c>.
+    /// </summary>
+    public string? ConditionalFormat { get; private set; }
+
+    /// <summary>
     /// Initializes a column configuration for an OUTPUT column (formula/calculated).
     /// FieldType is automatically inferred from the property type.
     /// This is the most common case - use this constructor for columns with formulas.
@@ -199,6 +210,7 @@ public class ColumnAttribute : Attribute
         Note = options.Note;
         IgnoreMappingErrors = options.IgnoreMappingErrors;
         NamedRange = options.NamedRange;
+        ConditionalFormat = options.ConditionalFormat;
     }
 
     /// <summary>
@@ -216,13 +228,14 @@ public class ColumnAttribute : Attribute
     /// <param name="formatType">Format type for Google Sheets display (DEFAULT = use default from fieldType)</param>
     /// <param name="ignoreMappingErrors">Suppress mapping-error diagnostics for this column (see <see cref="IgnoreMappingErrors"/>)</param>
     /// <param name="namedRange">Give this column's data a named range (see <see cref="NamedRange"/>)</param>
-    // 10 params is intentional: this is the convenience overload for named-argument call sites
+    /// <param name="conditionalFormat">Domain-specific conditional-format rule identifier (see <see cref="ConditionalFormat"/>)</param>
+    // 11 params is intentional: this is the convenience overload for named-argument call sites
     // (used pervasively across every domain's entities); the ColumnOptions-based overload above
     // is the designed escape hatch when more configuration is needed. Note that the ColumnOptions
     // overload can only ever be called programmatically, not as a declarative [Column(...)]
     // attribute - attribute arguments must be compile-time constants, and ColumnOptions is a mutable
     // object initializer. This constructor is therefore the only one that can expose a new option
-    // (like ignoreMappingErrors/namedRange) to code actually using [Column(...)] syntax.
+    // (like ignoreMappingErrors/namedRange/conditionalFormat) to code actually using [Column(...)] syntax.
 #pragma warning disable S107
     public ColumnAttribute(
         string headerName,
@@ -234,7 +247,8 @@ public class ColumnAttribute : Attribute
         int order = -1,
         Format formatType = Format.DEFAULT,
         bool ignoreMappingErrors = false,
-        bool namedRange = false)
+        bool namedRange = false,
+        string? conditionalFormat = null)
     {
         HeaderName = headerName ?? throw new ArgumentNullException(nameof(headerName));
         FieldType = FieldType.String; // Default, will be set by SetFieldTypeFromProperty
@@ -248,6 +262,7 @@ public class ColumnAttribute : Attribute
         Note = note;
         IgnoreMappingErrors = ignoreMappingErrors;
         NamedRange = namedRange;
+        ConditionalFormat = conditionalFormat;
     }
 #pragma warning restore S107
 

--- a/RaptorSheets.Core/Attributes/ColumnAttribute.cs
+++ b/RaptorSheets.Core/Attributes/ColumnAttribute.cs
@@ -251,6 +251,16 @@ public class ColumnAttribute : Attribute
         string? conditionalFormat = null)
     {
         HeaderName = headerName ?? throw new ArgumentNullException(nameof(headerName));
+        // Null (never set) is fine; an explicitly-blank value would silently resolve to no
+        // conditional format (see ConditionalFormat's own doc comment), masking what was likely
+        // meant to be a real rule identifier - reject it here instead.
+        if (conditionalFormat != null && string.IsNullOrWhiteSpace(conditionalFormat))
+        {
+            throw new ArgumentException(
+                "conditionalFormat must not be empty or whitespace - omit it (null) for no conditional format, or provide a real rule identifier.",
+                nameof(conditionalFormat));
+        }
+
         FieldType = FieldType.String; // Default, will be set by SetFieldTypeFromProperty
         IsFieldTypeExplicit = false;
         FormatType = formatType;

--- a/RaptorSheets.Core/Attributes/ColumnOptions.cs
+++ b/RaptorSheets.Core/Attributes/ColumnOptions.cs
@@ -89,6 +89,13 @@ public class ColumnOptions
     /// negative value is silently treated the same as -1 by <see cref="ColumnAttribute.HasExplicitOrder"/>,
     /// masking what was likely meant to be an explicit priority.
     /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <see cref="ConditionalFormat"/> is empty or whitespace. Unlike <see cref="ValidationPattern"/>
+    /// (which falls back to a FieldType default under the separate <see cref="EnableValidation"/>
+    /// flag), there's no such fallback here - a blank identifier would resolve to nothing and the
+    /// column would silently get no conditional format, masking what was likely meant to be a real
+    /// rule identifier. Null (never set) is fine; only an explicitly-blank value is rejected.
+    /// </exception>
     public void Validate()
     {
         if (Order < -1)
@@ -98,6 +105,15 @@ public class ColumnOptions
 #pragma warning disable S3928
             throw new ArgumentOutOfRangeException(nameof(Order), Order,
                 "Order must be -1 (use declaration order) or a non-negative explicit priority.");
+#pragma warning restore S3928
+        }
+
+        if (ConditionalFormat != null && string.IsNullOrWhiteSpace(ConditionalFormat))
+        {
+#pragma warning disable S3928
+            throw new ArgumentException(
+                "ConditionalFormat must not be empty or whitespace - omit it (null) for no conditional format, or provide a real rule identifier.",
+                nameof(ConditionalFormat));
 #pragma warning restore S3928
         }
     }

--- a/RaptorSheets.Core/Attributes/ColumnOptions.cs
+++ b/RaptorSheets.Core/Attributes/ColumnOptions.cs
@@ -64,6 +64,12 @@ public class ColumnOptions
     public bool NamedRange { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a domain-specific conditional-format rule identifier for this column
+    /// (default: null). See <see cref="ColumnAttribute.ConditionalFormat"/>.
+    /// </summary>
+    public string? ConditionalFormat { get; set; }
+
+    /// <summary>
     /// Creates a new ColumnOptions instance with default values.
     /// </summary>
     public ColumnOptions()
@@ -193,6 +199,16 @@ public class ColumnOptionsBuilder
     public ColumnOptionsBuilder WithNamedRange()
     {
         _options.NamedRange = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a domain-specific conditional-format rule identifier for this column - see
+    /// <see cref="ColumnAttribute.ConditionalFormat"/>.
+    /// </summary>
+    public ColumnOptionsBuilder WithConditionalFormat(string conditionalFormat)
+    {
+        _options.ConditionalFormat = conditionalFormat;
         return this;
     }
 

--- a/RaptorSheets.Core/Helpers/EntitySheetConfigHelper.cs
+++ b/RaptorSheets.Core/Helpers/EntitySheetConfigHelper.cs
@@ -95,7 +95,8 @@ public static class EntitySheetConfigHelper
         {
             Name = headerName,
             Format = columnAttr.GetEffectiveFormat(),
-            NamedRange = columnAttr.NamedRange
+            NamedRange = columnAttr.NamedRange,
+            ConditionalFormat = columnAttr.ConditionalFormat ?? ""
         };
 
         // Populate FormatPattern - this becomes the single source of truth

--- a/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
+++ b/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
@@ -466,6 +466,44 @@ public static class GoogleRequestHelpers
         return char.IsDigit(sanitized[0]) ? "_" + sanitized : sanitized;
     }
 
+    /// <summary>
+    /// Builds an AddConditionalFormatRuleRequest for a single header column flagged with
+    /// <see cref="RaptorSheets.Core.Attributes.ColumnAttribute.ConditionalFormat"/> (GitHub issue
+    /// #81) - the actual condition/format (<paramref name="rule"/>) is resolved by a domain's own
+    /// delegate; this only positions it on that column's data (row 1, the header, is excluded) and
+    /// assigns it <paramref name="ruleIndex"/> (the rule's position in the sheet's conditional
+    /// format list - Google requires this, and it must be unique per sheet in one batch).
+    /// </summary>
+    /// <returns>Null when <paramref name="rule"/> is null (nothing to add for this column).</returns>
+    public static Request? GenerateConditionalFormatRequest(int sheetId, int columnIndex, BooleanRule? rule, int ruleIndex)
+    {
+        if (rule == null)
+        {
+            return null;
+        }
+
+        var range = new GridRange
+        {
+            SheetId = sheetId,
+            StartColumnIndex = columnIndex,
+            EndColumnIndex = columnIndex + 1,
+            StartRowIndex = 1,
+        };
+
+        return new Request
+        {
+            AddConditionalFormatRule = new AddConditionalFormatRuleRequest
+            {
+                Index = ruleIndex,
+                Rule = new ConditionalFormatRule
+                {
+                    Ranges = [range],
+                    BooleanRule = rule
+                }
+            }
+        };
+    }
+
     public static Request GenerateSheetPropertes(SheetModel sheet)
     {
         var sheetRequest = new AddSheetRequest

--- a/RaptorSheets.Core/Helpers/SheetGenerationHelper.cs
+++ b/RaptorSheets.Core/Helpers/SheetGenerationHelper.cs
@@ -21,10 +21,12 @@ public static class SheetGenerationHelper
     /// <param name="sheets">Sheet names to generate requests for.</param>
     /// <param name="getSheetModel">Resolves a sheet name to its domain-configured SheetModel (headers, formulas, colors, protection).</param>
     /// <param name="getDataValidation">Resolves a header's raw <c>Validation</c> string to a concrete data validation rule; only called for headers where Validation is set.</param>
+    /// <param name="getConditionalFormat">Resolves a header's raw <c>ConditionalFormat</c> string to a concrete boolean rule; only called for headers where ConditionalFormat is set. Optional - domains that don't use conditional formatting can omit it.</param>
     public static BatchUpdateSpreadsheetRequest Generate(
         List<string> sheets,
         Func<string, SheetModel> getSheetModel,
-        Func<SheetCellModel, DataValidationRule?> getDataValidation)
+        Func<SheetCellModel, DataValidationRule?> getDataValidation,
+        Func<SheetCellModel, BooleanRule?>? getConditionalFormat = null)
     {
         if (sheets.Count == 0)
         {
@@ -51,7 +53,7 @@ public static class SheetGenerationHelper
             }
 
             batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateAppendCells(sheetModel));
-            GenerateHeadersFormatAndProtection(sheetModel, batchUpdateSpreadsheetRequest, repeatCellRequests, getDataValidation);
+            GenerateHeadersFormatAndProtection(sheetModel, batchUpdateSpreadsheetRequest, repeatCellRequests, getDataValidation, getConditionalFormat);
             batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateBandingRequest(sheetModel));
             batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateProtectedRangeForHeaderOrSheet(sheetModel));
         }
@@ -68,10 +70,16 @@ public static class SheetGenerationHelper
         SheetModel sheet,
         BatchUpdateSpreadsheetRequest batchUpdateSpreadsheetRequest,
         List<RepeatCellRequest> repeatCellRequests,
-        Func<SheetCellModel, DataValidationRule?> getDataValidation)
+        Func<SheetCellModel, DataValidationRule?> getDataValidation,
+        Func<SheetCellModel, BooleanRule?>? getConditionalFormat)
     {
         // Ensure headers have proper Column/Index assignments prior to formatting
         sheet.Headers.UpdateColumns();
+
+        // AddConditionalFormatRuleRequest.Index is this rule's position in the sheet's conditional
+        // format list - scoped per sheet (reset for each sheet in the outer loop), incremented as
+        // each flagged column adds one.
+        var conditionalFormatIndex = 0;
 
         foreach (var header in sheet.Headers)
         {
@@ -92,6 +100,18 @@ public static class SheetGenerationHelper
             if (header.NamedRange)
             {
                 batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateNamedRangeRequest(sheet, header));
+            }
+
+            if (!string.IsNullOrEmpty(header.ConditionalFormat) && getConditionalFormat != null)
+            {
+                var conditionalFormatRequest = GoogleRequestHelpers.GenerateConditionalFormatRequest(
+                    sheet.Id, header.Index, getConditionalFormat(header), conditionalFormatIndex);
+
+                if (conditionalFormatRequest != null)
+                {
+                    batchUpdateSpreadsheetRequest.Requests.Add(conditionalFormatRequest);
+                    conditionalFormatIndex++;
+                }
             }
 
             AddFormatAndValidationRequest(header, range, repeatCellRequests, getDataValidation);

--- a/RaptorSheets.Core/Models/Google/SheetCellModel.cs
+++ b/RaptorSheets.Core/Models/Google/SheetCellModel.cs
@@ -30,4 +30,8 @@ public class SheetCellModel
     // Opt-in: gives this column's data (excluding the header row) a Google Sheets named range,
     // named "{SheetName}_{HeaderName}". See ColumnAttribute.NamedRange.
     public bool NamedRange { get; set; } = false;
+
+    // Domain-specific conditional-format rule identifier, resolved into a concrete BooleanRule by
+    // a domain's own resolver at generation time. See ColumnAttribute.ConditionalFormat.
+    public string ConditionalFormat { get; set; } = "";
 }


### PR DESCRIPTION
## Summary

Second of three recommended Tier 1 features from #81's investigation ([comment](https://github.com/khanjal/RaptorSheets/issues/81#issuecomment-5235035913)), following named ranges (#110).

New `ColumnAttribute.ConditionalFormat` (string?, opt-in) — a domain-specific rule identifier (e.g. `"NEGATIVE_BALANCE"`), resolved into a concrete `BooleanRule` (condition + highlight format) by a domain's own delegate at generation time. This mirrors the existing `EnableValidation`/`ValidationPattern` → `DataValidationRule` pipeline exactly: Core doesn't know what the identifier means, only that a domain resolver will turn it into the real Google type.

`GoogleRequestHelpers.GenerateConditionalFormatRequest` wraps the resolved rule into an `AddConditionalFormatRuleRequest`, scoped to that column's data (header row excluded) — same `GridRange` shape as the existing per-column format/validation/protection requests. Each flagged column on a sheet gets a sequential rule index, since Google requires `AddConditionalFormatRuleRequest.Index` to be unique within a sheet's rule list.

`SheetGenerationHelper.Generate` gains an optional `getConditionalFormat` delegate (defaults to `null`) — backward compatible, so none of the 4 domains' existing call sites needed to change. Confirmed by a clean full-solution build with **zero source changes outside `RaptorSheets.Core`**.

## Scope note

Same decision as named ranges: this ships the capability only (resolver plumbing, generation-time). Not included, tracked as explicit follow-ups:
- **Reapply support** — Google references conditional format rules by list *index*, not a stable ID, so the "delete descending by index" precedent already in `GoogleRequestHelpers.cs` (from row deletion) is the template here — not banding's deterministic-ID update-in-place, or protection's `Description`-marker ownership scan.
- **A real domain example** — flagging an actual column (negative balances, overdue items, or surfacing #58's mapping-issue rows directly in-sheet) to prove the end-to-end payoff, per the #81 investigation's stated use cases.

## Test plan

- [x] New tests: `ColumnAttributeTests` (default/both constructors), `GoogleRequestHelpersTests` (range bounds excluding header row, null-rule passthrough), `SheetGenerationHelperTests` (resolver invoked only for flagged columns, sequential indexes across multiple flagged columns on one sheet, backward-compat with no resolver, resolver returning null adds nothing).
- [x] Full `Core.Tests` suite: 1179/1179 passed.
- [x] Full solution build: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)