### PR TITLE
Add opt-in basic filter for sheets (#81 Tier 1, final)

### DIFF
--- a/RaptorSheets.Core.Tests/Unit/Helpers/GoogleRequestHelpersTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/GoogleRequestHelpersTests.cs
@@ -444,6 +444,29 @@ public class GoogleRequestHelpersTests
     }
 
     [Fact]
+    public void GenerateBasicFilterRequest_ShouldCoverHeaderRowThroughDeclaredColumns()
+    {
+        // Arrange
+        var sheet = new SheetModel
+        {
+            Id = 5,
+            Headers = [new SheetCellModel { Name = "Date" }, new SheetCellModel { Name = "Amount" }]
+        };
+
+        // Act
+        var result = GoogleRequestHelpers.GenerateBasicFilterRequest(sheet);
+
+        // Assert
+        Assert.NotNull(result.SetBasicFilter);
+        var range = result.SetBasicFilter.Filter.Range;
+        Assert.Equal(5, range.SheetId);
+        Assert.Equal(0, range.StartRowIndex); // includes the header row (filter dropdowns live there)
+        Assert.Equal(0, range.StartColumnIndex);
+        Assert.Equal(2, range.EndColumnIndex);
+        Assert.Null(range.EndRowIndex); // open-ended: keeps applying as data rows are added
+    }
+
+    [Fact]
     public void GenerateSheetPropertes_ShouldReturnValidRequest()
     {
         // Arrange

--- a/RaptorSheets.Core.Tests/Unit/Helpers/SheetGenerationHelperTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/SheetGenerationHelperTests.cs
@@ -162,4 +162,25 @@ public class SheetGenerationHelperTests
 
         Assert.DoesNotContain(result.Requests, r => r.AddNamedRange != null);
     }
+
+    [Fact]
+    public void Generate_ForSheetFlaggedWithBasicFilter_AddsSetBasicFilterRequest()
+    {
+        var sheetModel = BuildSheetModel("Trips");
+        sheetModel.BasicFilter = true;
+
+        var result = SheetGenerationHelper.Generate(["Trips"], _ => sheetModel, _ => null);
+
+        Assert.Contains(result.Requests, r => r.SetBasicFilter != null);
+    }
+
+    [Fact]
+    public void Generate_ForSheetWithoutBasicFilterFlag_DoesNotAddSetBasicFilterRequest()
+    {
+        var sheetModel = BuildSheetModel("Trips"); // BasicFilter defaults to false
+
+        var result = SheetGenerationHelper.Generate(["Trips"], _ => sheetModel, _ => null);
+
+        Assert.DoesNotContain(result.Requests, r => r.SetBasicFilter != null);
+    }
 }

--- a/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
+++ b/RaptorSheets.Core/Helpers/GoogleRequestHelpers.cs
@@ -466,6 +466,34 @@ public static class GoogleRequestHelpers
         return char.IsDigit(sanitized[0]) ? "_" + sanitized : sanitized;
     }
 
+    /// <summary>
+    /// Builds a SetBasicFilterRequest for a sheet flagged with <see cref="SheetModel.BasicFilter"/>
+    /// (GitHub issue #81) - covers the header row through every declared column, open-ended on
+    /// rows so it keeps applying as data is added. A sheet has at most one basic filter, so this
+    /// is a whole-sheet request like <see cref="GenerateBandingRequest"/>, not per-column.
+    /// SetBasicFilterRequest always replaces any existing filter outright (Google's API, not a
+    /// choice made here), which is what makes this the simplest of #81's Tier 1 features to
+    /// eventually reapply - no add-vs-update branching needed the way banding/protection require.
+    /// </summary>
+    public static Request GenerateBasicFilterRequest(SheetModel sheet)
+    {
+        var range = new GridRange
+        {
+            SheetId = sheet.Id,
+            StartRowIndex = 0,
+            StartColumnIndex = 0,
+            EndColumnIndex = sheet.Headers.Count,
+        };
+
+        return new Request
+        {
+            SetBasicFilter = new SetBasicFilterRequest
+            {
+                Filter = new BasicFilter { Range = range }
+            }
+        };
+    }
+
     public static Request GenerateSheetPropertes(SheetModel sheet)
     {
         var sheetRequest = new AddSheetRequest

--- a/RaptorSheets.Core/Helpers/SheetGenerationHelper.cs
+++ b/RaptorSheets.Core/Helpers/SheetGenerationHelper.cs
@@ -54,6 +54,11 @@ public static class SheetGenerationHelper
             GenerateHeadersFormatAndProtection(sheetModel, batchUpdateSpreadsheetRequest, repeatCellRequests, getDataValidation);
             batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateBandingRequest(sheetModel));
             batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateProtectedRangeForHeaderOrSheet(sheetModel));
+
+            if (sheetModel.BasicFilter)
+            {
+                batchUpdateSpreadsheetRequest.Requests.Add(GoogleRequestHelpers.GenerateBasicFilterRequest(sheetModel));
+            }
         }
 
         foreach (var request in repeatCellRequests)

--- a/RaptorSheets.Core/Models/Google/SheetModel.cs
+++ b/RaptorSheets.Core/Models/Google/SheetModel.cs
@@ -13,4 +13,8 @@ public class SheetModel
     public bool ProtectSheet { get; set; }
     public int FreezeColumnCount { get; set; }
     public int FreezeRowCount { get; set; }
+
+    // Opt-in: gives the sheet a basic filter (sort/filter dropdown arrows on the header row)
+    // covering the header plus every declared column. Not automatic - not every sheet wants one.
+    public bool BasicFilter { get; set; }
 }


### PR DESCRIPTION
## Summary

Third and final Tier 1 feature from #81's investigation ([comment](https://github.com/khanjal/RaptorSheets/issues/81#issuecomment-5235035913)), completing the set alongside named ranges (#110) and conditional formatting (#111).

New `SheetModel.BasicFilter` (bool, default false) — unlike the other two Tier 1 features, this is a **whole-sheet** flag rather than per-column (a sheet has at most one basic filter), so it needed no `ColumnAttribute`/`EntitySheetConfigHelper` plumbing: it's a plain property a domain's `BaseSheet` sets directly, the same way `ProtectSheet`/`TabColor` already are.

`GoogleRequestHelpers.GenerateBasicFilterRequest` builds a `SetBasicFilterRequest` covering the header row through every declared column, open-ended on rows so it keeps applying as data is added. `SheetGenerationHelper.Generate` adds it per sheet when the flag is set, alongside the existing unconditional banding/protection requests.

## Scope note

Same as the other two: ships the capability only. Reapply support should actually be the **simplest** of the three to add later — `SetBasicFilterRequest` always replaces outright (Google's API behavior, not a choice made here), so there's no add-vs-update branching to design the way banding (deterministic ID), protection (`Description` marker), or conditional formatting (index-based) each needed.

This closes out #81 Tier 1. Tier 2 (pivot tables, then charts) and Tier 3 (deferred: merged cells, slicers, developer metadata) remain per the investigation comment.

## Test plan

- [x] New tests: `GoogleRequestHelpersTests` (range covers header row through declared columns, open-ended on rows), `SheetGenerationHelperTests` (flag true adds the request, flag false/default doesn't).
- [x] Full `Core.Tests` suite: 1172/1172 passed (1 failure during the run was confirmed pre-existing shared-live-API flakiness, unrelated to this change, by rerunning in isolation).
- [x] Full solution build: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)