### PR TITLE
Normalise and validate the dispatch version input

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -68,11 +68,47 @@ jobs:
             exit 1
           fi
         else
-          # Manual workflow dispatch
+          # Manual workflow dispatch. The version box is free text, so it arrives exactly as typed -
+          # unlike the release path above, nothing has stripped a prefix off it yet. Pasting a whole
+          # tag ("core/v5.0.2") used to sail through to `dotnet pack -p:PackageVersion=core/v5.0.2`,
+          # where the slash makes an invalid NuGet version and restore dies with a bare
+          # "MSB4181: RestoreTask returned false but did not log an error" - no mention of the
+          # version, which sends you looking at the SDK instead. Normalise here, then reject
+          # anything that still is not a version.
           PACKAGE="${{ github.event.inputs.package }}"
           VERSION="${{ github.event.inputs.version }}"
+
+          # Trim whitespace, then accept the same shapes the release tags use.
+          VERSION="$(echo "$VERSION" | tr -d '[:space:]')"
+          TYPED="$VERSION"
+
+          case "$VERSION" in
+            gig/*)   PREFIX="RaptorSheets.Gig";   VERSION=${VERSION#gig/} ;;
+            stock/*) PREFIX="RaptorSheets.Stock"; VERSION=${VERSION#stock/} ;;
+            core/*)  PREFIX="RaptorSheets.Core";  VERSION=${VERSION#core/} ;;
+            *)       PREFIX="" ;;
+          esac
+          VERSION=${VERSION#v}
+
+          # A tag prefix that disagrees with the chosen package means one of the two is a mistake -
+          # picking either silently would publish under the wrong package ID.
+          if [ -n "$PREFIX" ] && [ "$PREFIX" != "$PACKAGE" ]; then
+            echo "::error::Version '$TYPED' is prefixed for $PREFIX but the selected package is $PACKAGE."
+            echo "Pick one: either choose $PREFIX as the package, or enter the version without the prefix."
+            exit 1
+          fi
+
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+            echo "::error::'$TYPED' is not a valid version."
+            echo "Enter the version on its own, e.g. 5.0.1 - no package prefix and no leading 'v'."
+            exit 1
+          fi
+
+          if [ "$TYPED" != "$VERSION" ]; then
+            echo "Normalised version input '$TYPED' to '$VERSION'."
+          fi
         fi
-        
+
         echo "package=$PACKAGE" >> $GITHUB_OUTPUT
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Releasing: $PACKAGE version $VERSION"


### PR DESCRIPTION
## Why

The `workflow_dispatch` version box is free text, and unlike the release path nothing stripped a prefix off it:

```bash
PACKAGE="${{ github.event.inputs.package }}"
VERSION="${{ github.event.inputs.version }}"
```

Pasting a whole tag went straight through to `dotnet pack -p:PackageVersion=core/v5.0.2`. The slash makes an invalid NuGet version, and restore fails with:

```
error MSB4181: The "RestoreTask" task returned false but did not log an error
```

No mention of the version, so it reads like an SDK or restore problem. It cost a real release attempt — the run was debugged as a .NET 10 / `global.json` issue before the version input turned out to be the cause.

## What changed

`detect_package`'s dispatch branch now normalises then validates:

- **Trims whitespace** and strips a `gig/`, `stock/`, or `core/` prefix and a leading `v` — the same shapes the release tags already accept, so pasting a tag now just works instead of failing obscurely.
- **Rejects anything that still is not a version**, naming what was typed and what to type instead.
- **Rejects a prefix that disagrees with the selected package.** The actual mistake was `package=RaptorSheets.Gig` with `version=core/v5.0.2`; honouring either half silently would publish under the wrong package ID.

Failures use `::error::` so they surface in the run summary rather than only in the log.

The release-tag path is untouched — it already parsed prefixes correctly, and every release to date has gone through it.

## Verification

16 cases, covering what should be accepted, what should be rejected, and the mismatch:

```
--- the mistake that actually happened ---
  REJECT (prefix/package mismatch): RaptorSheets.Gig + 'core/v5.0.2'
--- should accept ---
  ACCEPT -> 5.0.1          (RaptorSheets.Gig + '5.0.1')
  ACCEPT -> 5.0.1          (RaptorSheets.Gig + 'v5.0.1')
  ACCEPT -> 5.0.1          (RaptorSheets.Gig + 'gig/v5.0.1')
  ACCEPT -> 5.0.1          (RaptorSheets.Gig + 'gig/5.0.1')
  ACCEPT -> 5.0.2          (RaptorSheets.Core + 'core/v5.0.2')
  ACCEPT -> 5.0.1          (RaptorSheets.Gig + '  5.0.1  ')
  ACCEPT -> 5.0.1-beta.1   (RaptorSheets.Gig + '5.0.1-beta.1')
  ACCEPT -> 2.0.15.1       (RaptorSheets.Gig + '2.0.15.1')
--- should reject ---
  REJECT (not a version):  RaptorSheets.Gig + '5.0'
  REJECT (not a version):  RaptorSheets.Gig + 'abc'
  REJECT (not a version):  RaptorSheets.Gig + ''
  REJECT (not a version):  RaptorSheets.Gig + 'v'
  REJECT (not a version):  RaptorSheets.Gig + '5.0.1/extra'
  REJECT (prefix/package mismatch): RaptorSheets.Core + 'gig/5.0.1'
```

The four-part case (`2.0.15.1`) is accepted deliberately — this repo has shipped versions in that shape, so the pattern allows it rather than rejecting a form already on NuGet. Pre-release suffixes are allowed for the same reason: not currently used, but valid NuGet and no reason to block.

## Notes for reviewers

- This cannot be fully exercised until a dispatch actually runs — the logic was verified by extracting it and running the cases above through bash, not by triggering a release.
- Not attempted: cross-checking the version against what is already on NuGet. A duplicate version still fails at push, which is a clear enough error and does not need pre-empting here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
