### PR TITLE
Render headers instead of an error when the query source is empty

### DIFF
--- a/RaptorSheets.Core.Tests/Unit/Helpers/GoogleFormulaBuilderTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/GoogleFormulaBuilderTests.cs
@@ -1,4 +1,4 @@
-using RaptorSheets.Core.Helpers;
+﻿using RaptorSheets.Core.Helpers;
 using Xunit;
 
 namespace RaptorSheets.Core.Tests.Unit.Helpers;
@@ -591,9 +591,41 @@ public class GoogleFormulaBuilderTests
         var result = GoogleFormulaBuilder.BuildQueryGroupTwoColumns("Name", "Address", "Trips!A2:A", "Trips!B2:B", "Count");
 
         // Assert
-        Assert.StartsWith("=QUERY({Trips!A2:A,Trips!B2:B},\"select Col1, Col2, count(Col1)", result);
+        Assert.Contains("QUERY({Trips!A2:A,Trips!B2:B},\"select Col1, Col2, count(Col1)", result);
         Assert.Contains("group by Col1, Col2 order by Col1 asc, count(Col1) desc", result);
         Assert.Contains("label Col1 'Name', Col2 'Address', count(Col1) 'Count'", result);
+    }
+
+    [Fact]
+    public void BuildQueryGroupTwoColumns_GuardsAgainstAnEmptySource()
+    {
+        // QUERY infers each column's type from its data. On a freshly created spreadsheet there is
+        // no data at all, so every column reads as text and sum()/avg() over it fails outright with
+        // AVG_SUM_ONLY_NUMERIC - the sheet renders as one big error before the user has typed
+        // anything. The sibling rollups avoid this only because SUMIF returns 0 over an empty range.
+        var result = GoogleFormulaBuilder.BuildQueryGroupTwoColumns(
+            "Name", "Address", "Trips!A2:A", "Trips!B2:B", "Trips",
+            new[] { ("Pay", "Trips!C2:C", "sum"), ("First", "Trips!D2:D", "min") });
+
+        // Emptiness is tested on the first grouping range - the query already discards rows where
+        // that column is null, so no rows there means no output rows either way.
+        Assert.StartsWith("=IF(COUNTA(Trips!A2:A)=0,", result);
+
+        // The fallback is the header row on its own, in the same order the query would label them.
+        Assert.Contains("{\"Name\",\"Address\",\"Trips\",\"Pay\",\"First\"}", result);
+
+        // The query itself is unchanged - the guard only decides which branch renders.
+        Assert.Contains("QUERY({Trips!A2:A,Trips!B2:B,Trips!C2:C,Trips!D2:D}", result);
+        Assert.Contains("sum(Col3), min(Col4)", result);
+    }
+
+    [Fact]
+    public void BuildQueryGroupTwoColumns_CountOnly_AlsoGuardsAgainstAnEmptySource()
+    {
+        var result = GoogleFormulaBuilder.BuildQueryGroupTwoColumns("Name", "Address", "Trips!A2:A", "Trips!B2:B", "Count");
+
+        Assert.StartsWith("=IF(COUNTA(Trips!A2:A)=0,", result);
+        Assert.Contains("{\"Name\",\"Address\",\"Count\"}", result);
     }
 
     [Fact]
@@ -621,7 +653,7 @@ public class GoogleFormulaBuilderTests
         var result = GoogleFormulaBuilder.BuildQueryGroupTwoColumns("Name", "Address", "Trips!A2:A", "Trips!B2:B", "Count", sumColumns);
 
         // Assert
-        Assert.StartsWith("=QUERY({Trips!A2:A,Trips!B2:B,Trips!C2:C,Trips!D2:D},", result);
+        Assert.Contains("QUERY({Trips!A2:A,Trips!B2:B,Trips!C2:C,Trips!D2:D},", result);
         Assert.Contains("select Col1, Col2, count(Col1), sum(Col3), sum(Col4)", result);
         Assert.Contains("label Col1 'Name', Col2 'Address', count(Col1) 'Count', sum(Col3) 'Pay', sum(Col4) 'Tips'", result);
     }
@@ -634,7 +666,7 @@ public class GoogleFormulaBuilderTests
 
         // Assert
         Assert.DoesNotContain("sum(", result);
-        Assert.StartsWith("=QUERY({Trips!A2:A,Trips!B2:B},\"select Col1, Col2, count(Col1)", result);
+        Assert.Contains("QUERY({Trips!A2:A,Trips!B2:B},\"select Col1, Col2, count(Col1)", result);
     }
 
     [Fact]
@@ -652,7 +684,7 @@ public class GoogleFormulaBuilderTests
         var result = GoogleFormulaBuilder.BuildQueryGroupTwoColumns("Name", "Address", "Trips!A2:A", "Trips!B2:B", "Count", aggregateColumns);
 
         // Assert
-        Assert.StartsWith("=QUERY({Trips!A2:A,Trips!B2:B,Trips!C2:C,Trips!D2:D,Trips!D2:D},", result);
+        Assert.Contains("QUERY({Trips!A2:A,Trips!B2:B,Trips!C2:C,Trips!D2:D,Trips!D2:D},", result);
         Assert.Contains("select Col1, Col2, count(Col1), sum(Col3), min(Col4), max(Col5)", result);
         Assert.Contains("label Col1 'Name', Col2 'Address', count(Col1) 'Count', sum(Col3) 'Pay', min(Col4) 'First Trip', max(Col5) 'Last Trip'", result);
     }

--- a/RaptorSheets.Core/Helpers/GoogleFormulaBuilder.cs
+++ b/RaptorSheets.Core/Helpers/GoogleFormulaBuilder.cs
@@ -124,11 +124,6 @@ public static class GoogleFormulaBuilder
     }
 
     /// <summary>
-    /// Builds a QUERY formula that groups two parallel ranges by the first two columns
-    /// and returns a header row plus a count column. This centralizes the common summary pattern.
-    /// </summary>
-
-    /// <summary>
     /// A one-row array literal of the given headers, used as the fallback when the source range is
     /// empty. QUERY infers each column's type from its data, so with no data at all every column is
     /// typed as text and any sum()/avg() over it fails with AVG_SUM_ONLY_NUMERIC - the whole sheet
@@ -152,6 +147,10 @@ public static class GoogleFormulaBuilder
         return "=IF(COUNTA(" + countRange + ")=0," + BuildHeaderOnlyFallback(headers) + "," + query.TrimStart('=') + ")";
     }
 
+    /// <summary>
+    /// Builds a QUERY formula that groups two parallel ranges by the first two columns
+    /// and returns a header row plus a count column. This centralizes the common summary pattern.
+    /// </summary>
     public static string BuildQueryGroupTwoColumns(string header1, string header2, string range1, string range2, string countHeader, bool countColumnIsSecond = false)
     {
         var countExpr = countColumnIsSecond ? "count(Col2)" : "count(Col1)";

--- a/RaptorSheets.Core/Helpers/GoogleFormulaBuilder.cs
+++ b/RaptorSheets.Core/Helpers/GoogleFormulaBuilder.cs
@@ -1,4 +1,4 @@
-using RaptorSheets.Core.Constants;
+﻿using RaptorSheets.Core.Constants;
 using System.Diagnostics.CodeAnalysis;
 
 namespace RaptorSheets.Core.Helpers;
@@ -127,6 +127,31 @@ public static class GoogleFormulaBuilder
     /// Builds a QUERY formula that groups two parallel ranges by the first two columns
     /// and returns a header row plus a count column. This centralizes the common summary pattern.
     /// </summary>
+
+    /// <summary>
+    /// A one-row array literal of the given headers, used as the fallback when the source range is
+    /// empty. QUERY infers each column's type from its data, so with no data at all every column is
+    /// typed as text and any sum()/avg() over it fails with AVG_SUM_ONLY_NUMERIC - the whole sheet
+    /// renders as an error on a freshly created spreadsheet, before the user has entered anything.
+    /// The sibling rollups escape this only because SUMIF returns 0 over an empty range rather than
+    /// erroring; the QUERY-based ones need the emptiness handled explicitly.
+    /// </summary>
+    private static string BuildHeaderOnlyFallback(IEnumerable<string> headers)
+    {
+        return "{" + string.Join(",", headers.Select(h => '"' + h + '"')) + "}";
+    }
+
+    /// <summary>
+    /// Wraps a QUERY so an empty source yields just the header row instead of an error. COUNTA on
+    /// the first grouping range is the emptiness test: the query already discards rows where that
+    /// column is null, so no rows there means no output rows either way - the guard changes what an
+    /// empty sheet renders, never what a populated one does.
+    /// </summary>
+    private static string GuardEmptySource(string countRange, IEnumerable<string> headers, string query)
+    {
+        return "=IF(COUNTA(" + countRange + ")=0," + BuildHeaderOnlyFallback(headers) + "," + query.TrimStart('=') + ")";
+    }
+
     public static string BuildQueryGroupTwoColumns(string header1, string header2, string range1, string range2, string countHeader, bool countColumnIsSecond = false)
     {
         var countExpr = countColumnIsSecond ? "count(Col2)" : "count(Col1)";
@@ -135,7 +160,7 @@ public static class GoogleFormulaBuilder
 
         var innerQuery = "\"select Col1, Col2, " + countExpr + " where Col1 is not null and Col2 is not null group by Col1, Col2 order by Col1 asc, " + countExpr + " desc label Col1 '" + header1 + "', Col2 '" + header2 + "', " + countExpr + " '" + countHeader + "'\",0";
 
-        return "=QUERY(" + ranges + "," + innerQuery + ")";
+        return GuardEmptySource(range1, [header1, header2, countHeader], "=QUERY(" + ranges + "," + innerQuery + ")");
     }
 
     /// <summary>
@@ -174,7 +199,10 @@ public static class GoogleFormulaBuilder
             " where Col1 is not null and Col2 is not null group by Col1, Col2 order by Col1 asc, " + countExpr +
             " desc label " + string.Join(", ", labelClauses) + "\",0";
 
-        return "=QUERY(" + ranges + "," + innerQuery + ")";
+        var headers = new List<string> { header1, header2, countHeader };
+        headers.AddRange(aggregateColumnList.Select(a => a.Header));
+
+        return GuardEmptySource(range1, headers, "=QUERY(" + ranges + "," + innerQuery + ")");
     }
 
     /// <summary>

--- a/RaptorSheets.Gig.Tests/Unit/Sheets/MapperGetSheetTests.cs
+++ b/RaptorSheets.Gig.Tests/Unit/Sheets/MapperGetSheetTests.cs
@@ -356,7 +356,10 @@ public class MapperGetSheetTests
         // are separate ARRAYFORMULAs placed after it.
         var queryFormula = sheet.Headers[0].Formula;
         Assert.NotNull(queryFormula);
-        Assert.StartsWith("=QUERY({", queryFormula);
+        // Guarded against an empty Trips sheet - see GuardEmptySource. QUERY types each column
+        // from its data, so with no trips every column reads as text and the sums fail.
+        Assert.StartsWith("=IF(COUNTA(", queryFormula);
+        Assert.Contains("QUERY({", queryFormula);
         Assert.Contains("select Col1, Col2, count(Col1), sum(Col3), sum(Col4), sum(Col5), sum(Col6), sum(Col7), min(Col8), max(Col9)", queryFormula);
         Assert.Contains("label Col1 'Name', Col2 'Address', count(Col1) 'Trips', sum(Col3) 'Pay', sum(Col4) 'Tips', sum(Col5) 'Bonus', sum(Col6) 'Total', sum(Col7) 'Dist', min(Col8) 'First Trip', max(Col9) 'Last Trip'", queryFormula);
 


### PR DESCRIPTION
## The bug

Deliveries and Locations rendered as one big error on a **freshly created** spreadsheet:

```
Unable to parse query string for Function QUERY parameter 2: AVG_SUM_ONLY_NUMERIC
```

QUERY infers each column's type from its data. With no trips entered yet there is nothing to infer from, so every column reads as text and the `sum()` aggregates are rejected outright — before the user has typed anything at all. A new user's first sight of those two sheets is a red error.

**Only these two sheets were affected, and that is the giveaway:** they are the only two built with `BuildQueryGroupTwoColumns`. Every other rollup — Daily, Weekly, Monthly, Yearly, Weekday, Region, Service, Place — aggregates with `BuildArrayFormulaSumIf`, and `SUMIF` returns 0 over an empty range instead of erroring. The two broken sheets map exactly onto the two using the fragile builder.

## The fix

Both overloads now wrap the query in a `COUNTA` check on the first grouping range, falling back to the header row alone:

```
=IF(COUNTA(Trips!R2:R)=0,{"Name","Address","Trips","Pay",…},QUERY({…},"select …",0))
```

That range is already the query's own filter (`where Col1 is not null`), so an empty one means no output rows either way. **The guard changes what an empty sheet renders, never what a populated one does.**

Verified live on a real spreadsheet, both empty and populated.

## Tests

Five existing assertions expected the formula to start with `"=QUERY("`, which is now the guard's false branch — relaxed to `Contains`. Two new tests pin the guard: that emptiness is tested on the first grouping range, that the fallback is the header row in label order, and that the query itself is untouched.

**1905 unit tests pass**, 0 warnings.

## What this says about our test coverage

Worth stating plainly, because it is the more important finding: **CI could never have caught this.** The unit tests assert formula *strings*. All 1905 of them passed against a formula Google rejects outright. The tests added here are no different — they pin the guard's shape, not its validity; the only reason we know it works is that it was pasted into a live sheet by hand.

The only layer that would catch this class of bug is the integration tests, which need `spreadsheets__test__gig` and the `google_credentials__*` secrets. Those are wired into `dotnet.yml`, but whether they actually execute — rather than skipping silently when config is absent — is unconfirmed. If they skip, CI is green while never touching a real sheet, and every formula change ships unverified.

I would treat that as a follow-up worth its own issue.

## Notes for reviewers

- The guard is in the shared Core builder, so any future domain using `BuildQueryGroupTwoColumns` inherits it. No other call sites exist today.
- `COUNTA` over an open-ended range on every recalculation is cheap, but it is a real addition to two formulas that recalc on edit. Not measurable at these row counts, worth knowing about.
- Header text is embedded into the fallback array literal, so a header containing a double quote would break it. None do, and header names come from `SheetsConfig`, not user input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
