### PR TITLE
Make skipped integration tests visible, and wire Core's spreadsheet

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,6 +42,34 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release
 
+    - name: Check integration test config
+      shell: bash
+      env:
+        spreadsheets__test__gig: ${{ secrets.GIG_SPREADSHEET_ID }}
+        spreadsheets__test__stock: ${{ secrets.STOCK_SPREADSHEET_ID }}
+        spreadsheets__test__job: ${{ secrets.JOB_SPREADSHEET_ID }}
+        spreadsheets__test__home: ${{ secrets.HOME_SPREADSHEET_ID }}
+        spreadsheets__test__core: ${{ secrets.CORE_SPREADSHEET_ID }}
+        google_credentials__private_key_id: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY_ID }}
+        google_credentials__private_key: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY }}
+        google_credentials__client_email: ${{ secrets.GOOGLE_CREDENTIALS_CLIENT_EMAIL }}
+        google_credentials__client_id: ${{ secrets.GOOGLE_CREDENTIALS_CLIENT_ID }}
+      run: |
+        # Integration tests skip themselves when credentials or a spreadsheet id are missing
+        # (FactCheckUserSecretsBaseAttribute), and a skip is not a failure - so an unset secret
+        # silently removes ~100 live-sheet tests while CI still reports green. Report presence
+        # up front. Values are never printed, only whether they arrived.
+        missing=0
+        for name in google_credentials__private_key_id google_credentials__private_key                     google_credentials__client_email google_credentials__client_id                     spreadsheets__test__gig spreadsheets__test__stock                     spreadsheets__test__job spreadsheets__test__home spreadsheets__test__core; do
+          if [ -z "${!name}" ]; then
+            echo "::warning::$name is empty - the integration tests that need it will skip."
+            missing=$((missing + 1))
+          else
+            echo "present: $name"
+          fi
+        done
+        echo "$missing of 9 integration-test settings are missing."
+
     - name: Run Tests
       shell: bash
       env:
@@ -49,7 +77,7 @@ jobs:
         spreadsheets__test__stock: ${{ secrets.STOCK_SPREADSHEET_ID }}
         spreadsheets__test__job: ${{ secrets.JOB_SPREADSHEET_ID }}
         spreadsheets__test__home: ${{ secrets.HOME_SPREADSHEET_ID }}
-        google_credentials__type: ${{ secrets.GOOGLE_CREDENTIALS_TYPE }}
+        spreadsheets__test__core: ${{ secrets.CORE_SPREADSHEET_ID }}
         google_credentials__private_key_id: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY_ID }}
         google_credentials__private_key: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY }}
         google_credentials__client_email: ${{ secrets.GOOGLE_CREDENTIALS_CLIENT_EMAIL }}
@@ -69,6 +97,32 @@ jobs:
         done
         echo "Tests failed after 3 attempts"
         exit 1
+
+    - name: Report skipped tests
+      if: always()
+      shell: bash
+      run: |
+        # A skipped test is not a failure, so ~100 skipped live-sheet tests look identical to a
+        # clean run in the checks UI. Surface the count in the job summary so a config regression
+        # is visible without reading the log. Deliberately does NOT fail the build yet: skips are
+        # currently non-zero, and failing here would block every PR before the credentials that
+        # cause them can be fixed. Once the count is genuinely 0, turn this into a hard failure.
+        skipped=$(grep -ho 'skipped="[0-9]*"' $(find . -name '*.trx') 2>/dev/null                   | grep -o '[0-9]*' | paste -sd+ - | bc)
+        skipped=${skipped:-0}
+        {
+          echo "## Test skips"
+          echo ""
+          if [ "$skipped" -eq 0 ]; then
+            echo "No tests skipped."
+          else
+            echo "**$skipped test(s) skipped.** Integration tests skip themselves when credentials"
+            echo "or a spreadsheet id are missing, so a non-zero count here means live-sheet"
+            echo "coverage did not run - see the \"Check integration test config\" step above."
+          fi
+        } >> $GITHUB_STEP_SUMMARY
+        if [ "$skipped" -ne 0 ]; then
+          echo "::warning::$skipped test(s) skipped - live-sheet coverage did not run."
+        fi
 
     - name: Upload Test Results
       if: always()
@@ -154,7 +208,7 @@ jobs:
         spreadsheets__test__stock: ${{ secrets.STOCK_SPREADSHEET_ID }}
         spreadsheets__test__job: ${{ secrets.JOB_SPREADSHEET_ID }}
         spreadsheets__test__home: ${{ secrets.HOME_SPREADSHEET_ID }}
-        google_credentials__type: ${{ secrets.GOOGLE_CREDENTIALS_TYPE }}
+        spreadsheets__test__core: ${{ secrets.CORE_SPREADSHEET_ID }}
         google_credentials__private_key_id: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY_ID }}
         google_credentials__private_key: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY }}
         google_credentials__client_email: ${{ secrets.GOOGLE_CREDENTIALS_CLIENT_EMAIL }}


### PR DESCRIPTION
## The problem

**All ~100 integration tests have been skipping in every CI run**, across all five domains, reported as `Ignore when missing user secrets`:

```
28  Stock.Tests.Integration.StockPlumbingTests
28  Job.Tests.Integration.JobPlumbingTests
28  Home.Tests.Integration.HomePlumbingTests
28  Gig.Tests.Integration.GigPlumbingTests
28  Core.Tests.Integration.CoreTest.CorePlumbingTests
18  Gig.Tests.Integration.GoogleSheetsIntegrationTests
…
```

A skip is not a failure, so the checks UI has been green the entire time while nothing touched a real spreadsheet.

That is not academic. It is **why the Deliveries/Locations `AVG_SUM_ONLY_NUMERIC` bug shipped** (#123): the unit tests compare formula *strings* and pass happily against a formula Google rejects outright. Only the live tests would have caught it, and they never ran.

## Changes

**Pass `spreadsheets__test__core`.** The `CORE_SPREADSHEET_ID` secret has existed since August but was never handed to the tests, so `GetCoreSpreadsheet()` always returned empty and Core's live plumbing coverage could not run even when everything else was configured. Wired into both the test job and the SonarCloud coverage job.

**Drop the `GOOGLE_CREDENTIALS_TYPE` reference.** No such secret exists, so it always expanded to empty. That turned out to be harmless — I tested it rather than assuming: .NET reads an absent env var as `null`, so the code's `?? "service_account"` default supplies the value. Removing the reference is clearer than creating a secret that only restates a default.

**Add a config presence check before the tests**, reporting which of the nine settings arrived — never their values, only presence — as `::warning::` annotations.

**Add a skip count after the tests**, written to the job summary, so a config regression is visible without reading the log.

## Why the skip count warns instead of failing

Skips are non-zero today. Failing on them would block every PR *before* the credentials causing them can be fixed — you would not be able to merge the fix.

**Once the count is genuinely 0, this should become a hard failure.** Otherwise it regresses silently the next time a secret lapses, which is exactly how we got here. That is a one-line change (`exit 1` in the non-zero branch) and worth doing as a follow-up rather than forgetting.

## What this does NOT fix

**It does not make the tests run.** Gig's four credential secrets and `GIG_SPREADSHEET_ID` are all present, yet its 28 integration tests still skip — so a value is empty, stale, or the service account has lost access to the sheets. `STOCK_SPREADSHEET_ID` dates from 2024-11 and `GIG_SPREADSHEET_ID` from 2025-10.

The presence check exists precisely to find out which. The first run of this branch should say.

## Secret inventory

Every `secrets.*` reference across all three workflows, against what the repo has:

| Secret | Status |
|---|---|
| `GIG_/STOCK_/HOME_/JOB_SPREADSHEET_ID` | keep — used |
| `CORE_SPREADSHEET_ID` | keep — **now actually used** |
| `GOOGLE_CREDENTIALS_CLIENT_EMAIL/CLIENT_ID/PRIVATE_KEY/PRIVATE_KEY_ID` | keep — used |
| `SONAR_TOKEN` | keep — used |
| `NUGET_USER` | keep — Trusted Publishing |
| `NUGET_API_KEY` | **safe to delete** — dead since #118; no workflow references it |
| `GOOGLE_CREDENTIALS_TYPE` | do not create — reference removed here |
| `GITHUB_TOKEN` | injected automatically; never create manually |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
